### PR TITLE
Update URL of ISO 29500 to use the latest ISO 29500 standard

### DIFF
--- a/docs/how-to-accept-all-revisions-in-a-word-processing-document.md
+++ b/docs/how-to-accept-all-revisions-in-a-word-processing-document.md
@@ -77,7 +77,7 @@ Using the Open XML SDK 2.5, you can create document structure and content using 
 | WordprocessingML Element | Open XML SDK 2.5 Class | Description |
 |---|---|---|
 | document | [Document](https://msdn.microsoft.com/library/office/documentformat.openxml.wordprocessing.document.aspx) | The root element for the main document part. |
-| body | [Body](https://msdn.microsoft.com/library/office/documentformat.openxml.wordprocessing.body.aspx) | The container for the block level structures such as paragraphs, tables, annotations and others specified in the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification. |
+| body | [Body](https://msdn.microsoft.com/library/office/documentformat.openxml.wordprocessing.body.aspx) | The container for the block level structures such as paragraphs, tables, annotations and others specified in the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification. |
 | p | [Paragraph](https://msdn.microsoft.com/library/office/documentformat.openxml.wordprocessing.paragraph.aspx) | A paragraph. |
 | r | [Run](https://msdn.microsoft.com/library/office/documentformat.openxml.wordprocessing.run.aspx) | A run. |
 | t | [Text](https://msdn.microsoft.com/library/office/documentformat.openxml.wordprocessing.text.aspx) | A range of text. |
@@ -86,7 +86,7 @@ Using the Open XML SDK 2.5, you can create document structure and content using 
 
 When you accept a revision mark, you change the properties of a paragraph either by deleting an existing text or inserting a new text. In the following sections, you read about three elements that are used in the code to change the paragraph contents, mainly, `<w: pPrChange\>` (Revision Information for Paragraph Properties), **`<w:del>`** (Deleted Paragraph), and **`<w:ins>`** (Inserted Table Row) elements.
 
-The following information from the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification introduces the **ParagraphPropertiesChange** element (**pPrChange**).
+The following information from the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification introduces the **ParagraphPropertiesChange** element (**pPrChange**).
 
 **pPrChange (Revision Information for Paragraph Properties)**
 
@@ -116,7 +116,7 @@ The element specifies that there was a revision to the paragraph properties at 0
 
 ## Deleted Element
 
-The following information from the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification
+The following information from the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification
 introduces the Deleted element (**del**).
 
 **del (Deleted Paragraph)**
@@ -157,7 +157,7 @@ and this deletion was tracked as a revision.
 
 ## The Inserted Element
 
-The following information from the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification
+The following information from the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification
 introduces the Inserted element (**ins**).
 
 **ins (Inserted Table Row)**

--- a/docs/how-to-add-a-comment-to-a-slide-in-a-presentation.md
+++ b/docs/how-to-add-a-comment-to-a-slide-in-a-presentation.md
@@ -76,7 +76,7 @@ object that is created or named in the **using** statement, in this case *doc*.
 
 The basic document structure of a **PresentationML** document consists of a number of
 parts, among which is the main part that contains the presentation
-definition. The following text from the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification
+definition. The following text from the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification
 introduces the overall form of a **PresentationML** package.
 
 > The main part of a **PresentationML** package

--- a/docs/how-to-add-a-new-document-part-that-receives-a-relationship-id-to-a-package.md
+++ b/docs/how-to-add-a-new-document-part-that-receives-a-relationship-id-to-a-package.md
@@ -42,7 +42,7 @@ this topic.
 -----------------------------------------------------------------------------
 ## Packages and Document Parts 
 An Open XML document is stored as a package, whose format is defined by
-[ISO/IEC 29500-2](http://go.microsoft.com/fwlink/?LinkId=194337). The
+[ISO/IEC 29500-2](https://www.iso.org/standard/71691.html). The
 package can have multiple parts with relationships between them. The
 relationship between parts controls the category of the document. A
 document can be defined as a word-processing document if its

--- a/docs/how-to-add-a-new-document-part-to-a-package.md
+++ b/docs/how-to-add-a-new-document-part-to-a-package.md
@@ -36,7 +36,7 @@ this topic.
 -----------------------------------------------------------------------------
 ## Packages and Document Parts 
 An Open XML document is stored as a package, whose format is defined by
-[ISO/IEC 29500-2](http://go.microsoft.com/fwlink/?LinkId=194337). The
+[ISO/IEC 29500-2](https://www.iso.org/standard/71691.html). The
 package can have multiple parts with relationships between them. The
 relationship between parts controls the category of the document. A
 document can be defined as a word-processing document if its

--- a/docs/how-to-apply-a-style-to-a-paragraph-in-a-word-processing-document.md
+++ b/docs/how-to-apply-a-style-to-a-paragraph-in-a-word-processing-document.md
@@ -141,7 +141,7 @@ correspond to the **document**, **body**, **p**, **r**, and **t** elements.
 | WordprocessingML Element | Open XML SDK 2.5 Class | Description |
 |---|---|---|
 | document | [Document](https://msdn.microsoft.com/library/office/documentformat.openxml.wordprocessing.document.aspx) | The root element for the main document part. |
-| body | [Body](https://msdn.microsoft.com/library/office/documentformat.openxml.wordprocessing.body.aspx) | The container for the block level structures such as paragraphs, tables, annotations and others specified in the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification. |
+| body | [Body](https://msdn.microsoft.com/library/office/documentformat.openxml.wordprocessing.body.aspx) | The container for the block level structures such as paragraphs, tables, annotations and others specified in the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification. |
 | p | [Paragraph](https://msdn.microsoft.com/library/office/documentformat.openxml.wordprocessing.paragraph.aspx) | A paragraph. |
 | r | [Run](https://msdn.microsoft.com/library/office/documentformat.openxml.wordprocessing.run.aspx) | A run. |
 | t | [Text](https://msdn.microsoft.com/library/office/documentformat.openxml.wordprocessing.text.aspx) | A range of text. |

--- a/docs/how-to-apply-a-theme-to-a-presentation.md
+++ b/docs/how-to-apply-a-theme-to-a-presentation.md
@@ -87,7 +87,7 @@ object that is created or named in the **using** statement, in this case **theme
 ## Basic Presentation Document Structure
 The basic document structure of a **PresentationML** document consists of the main part
 that contains the presentation definition. The following text from the
-[ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337)
+[ISO/IEC 29500](https://www.iso.org/standard/71691.html)
 specification introduces the overall form of a **PresentationML** package.
 
 > A **PresentationML** package's main part
@@ -164,7 +164,7 @@ correspond to the **sld**, **sldLayout**, **sldMaster**, and **notesMaster** ele
 
 -----------------------------------------------------------------------------
 ## Structure of the Theme Element
-The following information from the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification can
+The following information from the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification can
 be useful when working with this element.
 
 > This element defines the root level complex type associated with a

--- a/docs/how-to-calculate-the-sum-of-a-range-of-cells-in-a-spreadsheet-document.md
+++ b/docs/how-to-calculate-the-sum-of-a-range-of-cells-in-a-spreadsheet-document.md
@@ -135,7 +135,7 @@ the **workbook**, **sheets**, **sheet**, **worksheet**, and **sheetData** elemen
 | SpreadsheetML Element | Open XML SDK 2.5 Class | Description |
 |---|---|---|
 | workbook | DocumentFormat.OpenXml.Spreadsheet.Workbook | The root element for the main document part. |
-| sheets | DocumentFormat.OpenXml.Spreadsheet.Sheets | The container for the block level structures such as sheet, fileVersion, and others specified in the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification. |
+| sheets | DocumentFormat.OpenXml.Spreadsheet.Sheets | The container for the block level structures such as sheet, fileVersion, and others specified in the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification. |
 | sheet | DocumentFormat.OpenXml.Spreadsheet.Sheet | A sheet that points to a sheet definition file. |
 | worksheet | DocumentFormat.OpenXml.Spreadsheet.Worksheet | A sheet definition file that contains the sheet data. |
 | sheetData | DocumentFormat.OpenXml.Spreadsheet.SheetData | The cell table, grouped together by rows. |

--- a/docs/how-to-change-the-fill-color-of-a-shape-in-a-presentation.md
+++ b/docs/how-to-change-the-fill-color-of-a-shape-in-a-presentation.md
@@ -77,7 +77,7 @@ The basic document structure of a PresentationML document consists of a
 number of parts, among which is the Shape Tree (**sp
 Tree**) element.
 
-The following text from the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification
+The following text from the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification
 introduces the overall form of a **PresentationML** package.
 
 > This element specifies all shapes within a slide. Contained within

--- a/docs/how-to-copy-the-contents-of-an-open-xml-package-part-to-a-document-part-in-a-dif.md
+++ b/docs/how-to-copy-the-contents-of-an-open-xml-package-part-to-a-document-part-in-a-dif.md
@@ -37,7 +37,7 @@ this topic.
 --------------------------------------------------------------------------------
 ## Packages and Document Parts
 An Open XML document is stored as a package, whose format is defined by
-[ISO/IEC 29500-2](http://go.microsoft.com/fwlink/?LinkId=194337). The
+[ISO/IEC 29500-2](https://www.iso.org/standard/71691.html). The
 package can have multiple parts with relationships between them. The
 relationship between parts controls the category of the document. A
 document can be defined as a word-processing document if its
@@ -119,7 +119,7 @@ correspond to the **document**, **body**, **p**, **r**, and **t** elements.
 | WordprocessingML Element | Open XML SDK 2.5 Class | Description |
 |---|---|---|
 | document | [Document](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.document.aspx) | The root element for the main document part. |
-| body | [Body](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.body.aspx) | The container for the block level structures such as paragraphs, tables, annotations and others specified in the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification. |
+| body | [Body](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.body.aspx) | The container for the block level structures such as paragraphs, tables, annotations and others specified in the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification. |
 | p | [Paragraph](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.paragraph.aspx) | A paragraph. |
 | r | [Run](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.run.aspx) | A run. |
 | t | [Text](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.text.aspx) | A range of text. |
@@ -127,7 +127,7 @@ correspond to the **document**, **body**, **p**, **r**, and **t** elements.
 --------------------------------------------------------------------------------
 ## The Theme Part
 The theme part contains information about the color, font, and format of
-a document. It is defined in the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification as
+a document. It is defined in the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification as
 follows.
 
 An instance of this part type contains information about a document's

--- a/docs/how-to-create-a-package.md
+++ b/docs/how-to-create-a-package.md
@@ -40,7 +40,7 @@ this topic.
 ## Packages and Document Parts
 
 An Open XML document is stored as a package, whose format is defined by
-[ISO/IEC 29500-2](http://go.microsoft.com/fwlink/?LinkId=194337). The
+[ISO/IEC 29500-2](https://www.iso.org/standard/71691.html). The
 package can have multiple parts with relationships between them. The
 relationship between parts controls the category of the document. A
 document can be defined as a word-processing document if its
@@ -133,7 +133,7 @@ correspond to the **document**, **body**, **p**, **r**, and **t** elements:
 | WordprocessingML Element | Open XML SDK 2.5 Class | Description |
 |---|---|---|
 | document | [Document](https://msdn.microsoft.com/library/office/documentformat.openxml.wordprocessing.document.aspx) | The root element for the main document part. |
-| body | [Body](https://msdn.microsoft.com/library/office/documentformat.openxml.wordprocessing.body.aspx) | The container for the block level structures such as paragraphs, tables, annotations, and others specified in the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification. |
+| body | [Body](https://msdn.microsoft.com/library/office/documentformat.openxml.wordprocessing.body.aspx) | The container for the block level structures such as paragraphs, tables, annotations, and others specified in the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification. |
 | p | [Paragraph](https://msdn.microsoft.com/library/office/documentformat.openxml.wordprocessing.paragraph.aspx) | A paragraph. |
 | r | [Run](https://msdn.microsoft.com/library/office/documentformat.openxml.wordprocessing.run.aspx) | A run. |
 | t | [Text](https://msdn.microsoft.com/library/office/documentformat.openxml.wordprocessing.text.aspx) | A range of text. |

--- a/docs/how-to-create-a-spreadsheet-document-by-providing-a-file-name.md
+++ b/docs/how-to-create-a-spreadsheet-document-by-providing-a-file-name.md
@@ -129,7 +129,7 @@ the **workbook**, **sheets**, **sheet**, **worksheet**, and **sheetData** elemen
 | SpreadsheetML Element | Open XML SDK 2.5 Class | Description |
 |---|---|---|
 | workbook | DocumentFormat.OpenXml.Spreadsheet.Workbook | The root element for the main document part. |
-| sheets | DocumentFormat.OpenXml.Spreadsheet.Sheets | The container for the block-level structures such as sheet, fileVersion, and others specified in the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification. |
+| sheets | DocumentFormat.OpenXml.Spreadsheet.Sheets | The container for the block-level structures such as sheet, fileVersion, and others specified in the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification. |
 | sheet | DocumentFormat.OpenXml.Spreadsheet.Sheet | A sheet that points to a sheet definition file. |
 | worksheet | DocumentFormat.OpenXml.Spreadsheet.Worksheet | A sheet definition file that contains the sheet data. |
 | sheetData | DocumentFormat.OpenXml.Spreadsheet.SheetData | The cell table, grouped together by rows. |

--- a/docs/how-to-create-a-word-processing-document-by-providing-a-file-name.md
+++ b/docs/how-to-create-a-word-processing-document-by-providing-a-file-name.md
@@ -126,7 +126,7 @@ correspond to the **document**, **body**, **p**, **r**, and **t** elements.
 | WordprocessingML Element | Open XML SDK 2.5 Class | Description |
 |---|---|---|
 | document | [Document](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.document.aspx) | The root element for the main document part. |
-| body | [Body](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.body.aspx) | The container for the block level structures such as paragraphs, tables, annotations, and others specified in the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification. |
+| body | [Body](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.body.aspx) | The container for the block level structures such as paragraphs, tables, annotations, and others specified in the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification. |
 | p | [Paragraph](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.paragraph.aspx) | A paragraph. |
 | r | [Run](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.run.aspx) | A run. |
 | t | [Text](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.text.aspx) | A range of text. |

--- a/docs/how-to-create-and-add-a-character-style-to-a-word-processing-document.md
+++ b/docs/how-to-create-and-add-a-character-style-to-a-word-processing-document.md
@@ -239,7 +239,7 @@ second run.
 
 WordprocessingML supports six style types, four of which you can specify
 using the type attribute on the style element. The following
-information, from section 17.7.4.17 in the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification,
+information, from section 17.7.4.17 in the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification,
 introduces style types.
 
 *Style types* refers to the property on a style which defines the type
@@ -390,7 +390,7 @@ The code next creates the child elements of the style, which define the
 properties of the style. To create an element, you instantiate its
 corresponding class, and then call the [Append(\[\])](https://msdn.microsoft.com/library/office/cc801361.aspx) method to add the child element
 to the style. For more information about these properties, see section
-17.7 of the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification.
+17.7 of the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification.
 
 ```csharp
     // Create and add the child elements (properties of the style).

--- a/docs/how-to-create-and-add-a-paragraph-style-to-a-word-processing-document.md
+++ b/docs/how-to-create-and-add-a-paragraph-style-to-a-word-processing-document.md
@@ -233,7 +233,7 @@ applies the style to the paragraph.
 
 WordprocessingML supports six style types, four of which you can specify
 using the type attribute on the style element. The following
-information, from section 17.7.4.17 in the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification,
+information, from section 17.7.4.17 in the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification,
 introduces style types.
 
 *Style types* refers to the property on a style which defines the type
@@ -388,7 +388,7 @@ The code next creates the child elements of the style, which define the
 properties of the style. To create an element, you instantiate its
 corresponding class, and then call the **[Append([])](https://msdn.microsoft.com/en-us/library/office/cc801361.aspx)** method add the child element to
 the style. For more information about these properties, see section 17.7
-of the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337)
+of the [ISO/IEC 29500](https://www.iso.org/standard/71691.html)
 specification.
 
 ```csharp

--- a/docs/how-to-delete-a-slide-from-a-presentation.md
+++ b/docs/how-to-delete-a-slide-from-a-presentation.md
@@ -116,7 +116,7 @@ object that is created or named in the **using** statement, in this case **prese
 
 The basic document structure of a **PresentationML** document consists of the main part
 that contains the presentation definition. The following text from the
-[ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337)
+[ISO/IEC 29500](https://www.iso.org/standard/71691.html)
 specification introduces the overall form of a **PresentationML** package.
 
 > A **PresentationML** package's main part

--- a/docs/how-to-delete-all-the-comments-by-an-author-from-all-the-slides-in-a-presentatio.md
+++ b/docs/how-to-delete-all-the-comments-by-an-author-from-all-the-slides-in-a-presentatio.md
@@ -85,7 +85,7 @@ object that is created or named in the **using** statement, in this case *doc*.
 
 The basic document structure of a **PresentationML** document consists of the main part
 that contains the presentation definition. The following text from the
-[ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337)
+[ISO/IEC 29500](https://www.iso.org/standard/71691.html)
 specification introduces the overall form of a **PresentationML** package.
 
 > A **PresentationML** package's main part
@@ -162,7 +162,7 @@ correspond to the **sld**, **sldLayout**, **sldMaster**, and **notesMaster** ele
 
 ## The Structure of the Comment Element
 
-The following text from the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification
+The following text from the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification
 introduces comments in a presentation package.
 
 > A comment is a text note attached to a slide, with the primary purpose

--- a/docs/how-to-delete-text-from-a-cell-in-a-spreadsheet.md
+++ b/docs/how-to-delete-text-from-a-cell-in-a-spreadsheet.md
@@ -128,7 +128,7 @@ the **workbook**, **sheets**, **sheet**, **worksheet**, and **sheetData** elemen
 | SpreadsheetML Element | Open XML SDK 2.5 Class | Description |
 |---|---|---|
 | workbook | DocumentFormat.OpenXML.Spreadsheet.Workbook | The root element for the main document part. |
-| sheets | DocumentFormat.OpenXML.Spreadsheet.Sheets | The container for the block level structures such as sheet, fileVersion, and others specified in the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification. |
+| sheets | DocumentFormat.OpenXML.Spreadsheet.Sheets | The container for the block level structures such as sheet, fileVersion, and others specified in the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification. |
 | sheet | DocumentFormat.OpenXml.Spreadsheet.Sheet | A sheet that points to a sheet definition file. |
 | worksheet | DocumentFormat.OpenXML.Spreadsheet. Worksheet | A sheet definition file that contains the sheet data. |
 | sheetData | DocumentFormat.OpenXML.Spreadsheet.SheetData | The cell table, grouped together by rows. |

--- a/docs/how-to-get-a-column-heading-in-a-spreadsheet.md
+++ b/docs/how-to-get-a-column-heading-in-a-spreadsheet.md
@@ -120,7 +120,7 @@ the **workbook**, **sheets**, **sheet**, **worksheet**, and **sheetData** elemen
 | SpreadsheetML Element | Open XML SDK 2.5 Class | Description |
 |---|---|---|
 | workbook | **Workbook** | The root element for the main document part. |
-| sheets | DocumentFormat.OpenXml.Spreadsheet.Sheets | The container for the block level structures such as sheet, fileVersion, and others specified in the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification. |
+| sheets | DocumentFormat.OpenXml.Spreadsheet.Sheets | The container for the block level structures such as sheet, fileVersion, and others specified in the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification. |
 | sheet | DocumentFormat.OpenXml.Spreadsheet.Sheet | A sheet that points to a sheet definition file. |
 | worksheet | DocumentFormat.OpenXml.Spreadsheet.Worksheet | A sheet definition file that contains the sheet data. |
 | sheetData | DocumentFormat.OpenXml.Spreadsheet.SheetData | The cell table, grouped together by rows. |

--- a/docs/how-to-get-all-the-external-hyperlinks-in-a-presentation.md
+++ b/docs/how-to-get-all-the-external-hyperlinks-in-a-presentation.md
@@ -80,7 +80,7 @@ object that is created or named in the **using** statement, in this case **docum
 ## Basic Presentation Document Structure
 The basic document structure of a **PresentationML** document consists of the main part
 that contains the presentation definition. The following text from the
-[ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337)
+[ISO/IEC 29500](https://www.iso.org/standard/71691.html)
 specification introduces the overall form of a **PresentationML** package.
 
 > A **PresentationML** package's main part
@@ -161,7 +161,7 @@ correspond to the **sld**, **sldLayout**, **sldMaster**, and **notesMaster** ele
 In this how-to code example, you are going to work with external
 hyperlinks. Therefore, it is best to familiarize yourself with the
 hyperlink element. The following text from the [ISO/IEC
-29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification
+29500](https://www.iso.org/standard/71691.html) specification
 introduces the **id** (Hyperlink Target).
 
 > Specifies the ID of the relationship whose target shall be used as the

--- a/docs/how-to-get-all-the-text-in-a-slide-in-a-presentation.md
+++ b/docs/how-to-get-all-the-text-in-a-slide-in-a-presentation.md
@@ -82,7 +82,7 @@ object that is created or named in the **using** statement, in this case **prese
 ## Basic Presentation Document Structure
 The basic document structure of a **PresentationML** document consists of the main part
 that contains the presentation definition. The following text from the
-[ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337)
+[ISO/IEC 29500](https://www.iso.org/standard/71691.html)
 specification introduces the overall form of a **PresentationML** package.
 
 > A PresentationML package's main part starts with a presentation root

--- a/docs/how-to-get-all-the-text-in-all-slides-in-a-presentation.md
+++ b/docs/how-to-get-all-the-text-in-all-slides-in-a-presentation.md
@@ -87,7 +87,7 @@ object that is created or named in the **using** statement, in this case **prese
 The basic document structure of a **PresentationML** document consists of a number of
 parts, among which is the main part that contains the presentation
 definition. The following text from the [ISO/IEC
-29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification
+29500](https://www.iso.org/standard/71691.html) specification
 introduces the overall form of a **PresentationML** package.
 
 A **PresentationML** package's main part starts

--- a/docs/how-to-get-the-contents-of-a-document-part-from-a-package.md
+++ b/docs/how-to-get-the-contents-of-a-document-part-from-a-package.md
@@ -37,7 +37,7 @@ this topic.
 --------------------------------------------------------------------------------
 ## Packages and Document Parts
 An Open XML document is stored as a package, whose format is defined by
-[ISO/IEC 29500-2](http://go.microsoft.com/fwlink/?LinkId=194337). The
+[ISO/IEC 29500-2](https://www.iso.org/standard/71691.html). The
 package can have multiple parts with relationships between them. The
 relationship between parts controls the category of the document. A
 document can be defined as a word-processing document if its
@@ -116,7 +116,7 @@ correspond to the **document**, **body**, **p**, **r**, and **t** elements.
 | WordprocessingML Element | Open XML SDK 2.5 Class | Description |
 |---|---|---|
 | document | [Document](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.document.aspx) | The root element for the main document part. |
-| body | [Body](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.body.aspx) | The container for the block level structures such as paragraphs, tables, annotations, and others specified in the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification. |
+| body | [Body](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.body.aspx) | The container for the block level structures such as paragraphs, tables, annotations, and others specified in the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification. |
 | p | [Paragraph](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.paragraph.aspx) | A paragraph. |
 | r | [Run](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.run.aspx) | A run. |
 | t | [Text](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.text.aspx) | A range of text. |
@@ -126,7 +126,7 @@ correspond to the **document**, **body**, **p**, **r**, and **t** elements.
 ## Comments Element
 In this how-to, you are going to work with comments. Therefore, it is
 useful to familiarize yourself with the structure of the \<**comments**\> element. The following information
-from the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337)
+from the [ISO/IEC 29500](https://www.iso.org/standard/71691.html)
 specification can be useful when working with this element.
 
 This element specifies all of the comments defined in the current

--- a/docs/how-to-get-the-titles-of-all-the-slides-in-a-presentation.md
+++ b/docs/how-to-get-the-titles-of-all-the-slides-in-a-presentation.md
@@ -86,7 +86,7 @@ object that is created or named in the **using** statement, in this case
 
 The basic document structure of a **PresentationML** document consists of the main part
 that contains the presentation definition. The following text from the
-[ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337)
+[ISO/IEC 29500](https://www.iso.org/standard/71691.html)
 specification introduces the overall form of a **PresentationML** package.
 
 > A **PresentationML** package's main part

--- a/docs/how-to-get-worksheet-information-from-a-package.md
+++ b/docs/how-to-get-worksheet-information-from-a-package.md
@@ -134,7 +134,7 @@ the **workbook**, **sheets**, **sheet**, **worksheet**, and **sheetData** elemen
 | SpreadsheetML Element | Open XML SDK 2.5 Class | Description |
 |---|---|---|
 | workbook | DocumentFormat.OpenXml.Spreadsheet.Workbook | The root element for the main document part. |
-| sheets | DocumentFormat.OpenXml.Spreadsheet.Sheets | The container for the block level structures such as sheet, fileVersion, and others specified in the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification. |
+| sheets | DocumentFormat.OpenXml.Spreadsheet.Sheets | The container for the block level structures such as sheet, fileVersion, and others specified in the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification. |
 | sheet | DocumentFormat.OpenXml.Spreadsheet.Sheet | A sheet that points to a sheet definition file. |
 | worksheet | DocumentFormat.OpenXml.Spreadsheet.Worksheet | A sheet definition file that contains the sheet data. |
 | sheetData | DocumentFormat.OpenXml.Spreadsheet.SheetData | The cell table, grouped together by rows. |

--- a/docs/how-to-insert-a-chart-into-a-spreadsheet.md
+++ b/docs/how-to-insert-a-chart-into-a-spreadsheet.md
@@ -143,7 +143,7 @@ the **workbook**, [Sheets](https://msdn.microsoft.com/library/office/documentfor
 | SpreadsheetML Element | Open XML SDK 2.5 Class | Description |
 |---|---|---|
 | workbook | DocumentFormat.OpenXml.Spreadsheet.Workbook | The root element for the main document part. |
-| sheets | DocumentFormat.OpenXml.Spreadsheet.Sheets | The container for the block level structures such as sheet, fileVersion, and others specified in the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification. |
+| sheets | DocumentFormat.OpenXml.Spreadsheet.Sheets | The container for the block level structures such as sheet, fileVersion, and others specified in the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification. |
 | sheet | DocumentFormat.OpenXml.Spreadsheet.Sheet | A sheet that points to a sheet definition file. |
 | worksheet | DocumentFormat.OpenXml.Spreadsheet.Worksheet | A sheet definition file that contains the sheet data. |
 | sheetData | DocumentFormat.OpenXml.Spreadsheet.SheetData | The cell table, grouped together by rows. |
@@ -156,7 +156,7 @@ the **workbook**, [Sheets](https://msdn.microsoft.com/library/office/documentfor
 
 In this how-to, you are going to deal with the row, cell, and cell value
 elements. Therefore it is useful to familiarize yourself with these
-elements. The following text from the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification
+elements. The following text from the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification
 introduces row (\<**row**\>) element.
 
 > The row element expresses information about an entire row of a
@@ -209,7 +209,7 @@ element.
 
 ## Cell Element
 
-The following text from the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification
+The following text from the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification
 introduces cell (\<**c**\>) element.
 
 > This collection represents a cell in the worksheet. Information about
@@ -252,7 +252,7 @@ element.
 
 ## Cell Value Element
 
-The following text from the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification
+The following text from the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification
 introduces Cell Value (\<**c**\>) element.
 
 > This element expresses the value contained in a cell. If the cell

--- a/docs/how-to-insert-a-new-slide-into-a-presentation.md
+++ b/docs/how-to-insert-a-new-slide-into-a-presentation.md
@@ -75,7 +75,7 @@ object that is created or named in the **using** statement, in this case
 
 The basic document structure of a **PresentationML** document consists of the main part
 that contains the presentation definition. The following text from the
-[ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337)
+[ISO/IEC 29500](https://www.iso.org/standard/71691.html)
 specification introduces the overall form of a **PresentationML** package.
 
 > A **PresentationML** package's main part

--- a/docs/how-to-insert-a-new-worksheet-into-a-spreadsheet.md
+++ b/docs/how-to-insert-a-new-worksheet-into-a-spreadsheet.md
@@ -127,7 +127,7 @@ the **workbook**, **sheets**, **sheet**, **worksheet**, and **sheetData** elemen
 | SpreadsheetML Element | Open XML SDK 2.5 Class | Description |
 |---|---|---|
 | workbook | DocumentFormat.OpenXml.Spreadsheet.Workbook | The root element for the main document part. |
-| sheets | DocumentFormat.OpenXml.Spreadsheet.Sheets | The container for the block level structures such as sheet, fileVersion, and others specified in the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification. |
+| sheets | DocumentFormat.OpenXml.Spreadsheet.Sheets | The container for the block level structures such as sheet, fileVersion, and others specified in the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification. |
 | sheet | DocumentFormat.OpenXml.Spreadsheet.Sheet | A sheet that points to a sheet definition file. |
 | worksheet | DocumentFormat.OpenXml.Spreadsheet.Worksheet | A sheet definition file that contains the sheet data. |
 | sheetData | DocumentFormat.OpenXml.Spreadsheet.SheetData | The cell table, grouped together by rows. |

--- a/docs/how-to-insert-a-picture-into-a-word-processing-document.md
+++ b/docs/how-to-insert-a-picture-into-a-word-processing-document.md
@@ -80,7 +80,7 @@ long as you use **using**.
 --------------------------------------------------------------------------------
 ## The XML Representation of the Graphic Object
 The following text from the [ISO/IEC
-29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification
+29500](https://www.iso.org/standard/71691.html) specification
 introduces the Graphic Object Data element.
 
 > This element specifies the reference to a graphic object within the

--- a/docs/how-to-insert-text-into-a-cell-in-a-spreadsheet.md
+++ b/docs/how-to-insert-text-into-a-cell-in-a-spreadsheet.md
@@ -128,7 +128,7 @@ the **workbook**, **sheets**, **sheet**, **worksheet**, and **sheetData** elemen
 | SpreadsheetML Element | Open XML SDK 2.5 Class | Description |
 |---|---|---|
 | workbook | DocumentFormat.OpenXml.Spreadsheet.Workbook | The root element for the main document part. |
-| sheets | DocumentFormat.OpenXml.Spreadsheet.Sheets | The container for the block level structures such as sheet, fileVersion, and others specified in the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification. |
+| sheets | DocumentFormat.OpenXml.Spreadsheet.Sheets | The container for the block level structures such as sheet, fileVersion, and others specified in the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification. |
 | sheet | DocumentFormat.OpenXml.Spreadsheet.Sheet | A sheet that points to a sheet definition file. |
 | worksheet | DocumentFormat.OpenXml.Spreadsheet.Worksheet | A sheet definition file that contains the sheet data. |
 | sheetData | DocumentFormat.OpenXml.Spreadsheet.SheetData | The cell table, grouped together by rows. |

--- a/docs/how-to-merge-two-adjacent-cells-in-a-spreadsheet.md
+++ b/docs/how-to-merge-two-adjacent-cells-in-a-spreadsheet.md
@@ -139,7 +139,7 @@ the **workbook**, **sheets**, **sheet**, **worksheet**, and **sheetData** elemen
 | SpreadsheetML Element | Open XML SDK 2.5 Class | Description |
 |---|---|---|
 | workbook | DocumentFormat.OpenXML.Spreadsheet.Workbook | The root element for the main document part. |
-| sheets | DocumentFormat. OpenXML.Spreadsheet.Sheets | The container for the block level structures such as sheet, fileVersion, and others specified in the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification. |
+| sheets | DocumentFormat. OpenXML.Spreadsheet.Sheets | The container for the block level structures such as sheet, fileVersion, and others specified in the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification. |
 | sheet | DocumentFormat.OpenXML.Spreadsheet.Sheet | A sheet that points to a sheet definition file. |
 | worksheet | DocumentFormat.OpenXML.Spreadsheet.Worksheet | A sheet definition file that contains the sheet data. |
 | sheetData | DocumentFormat.OpenXML.Spreadsheet.SheetData | The cell table, grouped together by rows. |

--- a/docs/how-to-move-a-paragraph-from-one-presentation-to-another.md
+++ b/docs/how-to-move-a-paragraph-from-one-presentation-to-another.md
@@ -75,7 +75,7 @@ object that is created or named in the **using** statement, in this case *doc*.
 
 The basic document structure of a **PresentationML** document consists of a number of
 parts, among which is the main part that contains the presentation
-definition. The following text from the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification
+definition. The following text from the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification
 introduces the overall form of a **PresentationML** package.
 
 > A **PresentationML** package's main part
@@ -152,7 +152,7 @@ correspond to the **sld**, **sldLayout**, **sldMaster**, and **notesMaster** ele
 
 ## Structure of the Shape Text Body
 
-The following text from the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification
+The following text from the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification
 introduces the structure of this element.
 
 > This element specifies the existence of text to be contained within

--- a/docs/how-to-move-a-slide-to-a-new-position-in-a-presentation.md
+++ b/docs/how-to-move-a-slide-to-a-new-position-in-a-presentation.md
@@ -81,7 +81,7 @@ object that is created or named in the **using** statement, in this case **prese
 The basic document structure of a **PresentationML** document consists of a number of
 parts, among which is the main part that contains the presentation
 definition. The following text from the [ISO/IEC
-29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification
+29500](https://www.iso.org/standard/71691.html) specification
 introduces the overall form of a **PresentationML** package.
 
 > A **PresentationML** package's main part

--- a/docs/how-to-open-a-presentation-document-for-read-only-access.md
+++ b/docs/how-to-open-a-presentation-document-for-read-only-access.md
@@ -150,7 +150,7 @@ code segment performs this operation.
 
 The basic document structure of a **PresentationML** document consists of a number of
 parts, among which the main part is that contains the presentation
-definition. The following text from the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification
+definition. The following text from the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification
 introduces the overall form of a **PresentationML** package.
 
 > The main part of a **PresentationML** package

--- a/docs/how-to-open-a-spreadsheet-document-for-read-only-access.md
+++ b/docs/how-to-open-a-spreadsheet-document-for-read-only-access.md
@@ -208,7 +208,7 @@ the **workbook**, **sheets**, **sheet**, **worksheet**, and **sheetData** elemen
 SpreadsheetML Element|Open XML SDK 2.5 Class|Description
 --|--|--
 workbook|DocumentFormat.OpenXml.Spreadsheet.Workbook|The root element for the main document part.
-sheets|DocumentFormat.OpenXml.Spreadsheet.Sheets|The container for the block level structures such as sheet, fileVersion, and others specified in the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification.
+sheets|DocumentFormat.OpenXml.Spreadsheet.Sheets|The container for the block level structures such as sheet, fileVersion, and others specified in the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification.
 sheet|DocumentFormat.OpenXml.Spreadsheet.Sheet|A sheet that points to a sheet definition file.
 worksheet|DocumentFormat.OpenXml.Spreadsheet.Worksheet|A sheet definition file that contains the sheet data.
 sheetData|DocumentFormat.OpenXml.Spreadsheet.SheetData|The cell table, grouped together by rows.

--- a/docs/how-to-open-a-spreadsheet-document-from-a-stream.md
+++ b/docs/how-to-open-a-spreadsheet-document-from-a-stream.md
@@ -143,7 +143,7 @@ the **workbook**, **sheets**, **sheet**, **worksheet**, and **sheetData** elemen
 SpreadsheetML Element|Open XML SDK 2.5 Class|Description
 --|--|--
 workbook|DocumentFormat.OpenXml.Spreadsheet.Workbook|The root element for the main document part.
-sheets|DocumentFormat.OpenXml.Spreadsheet.Sheets|The container for the block level structures such as sheet, fileVersion, and others specified in the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification.
+sheets|DocumentFormat.OpenXml.Spreadsheet.Sheets|The container for the block level structures such as sheet, fileVersion, and others specified in the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification.
 sheet|DocumentFormat.OpenXml.Spreadsheet.Sheet|A sheet that points to a sheet definition file.
 worksheet|DocumentFormat.OpenXml.Spreadsheet.Worksheet|A sheet definition file that contains the sheet data.
 sheetData|DocumentFormat.OpenXml.Spreadsheet.SheetData|The cell table, grouped together by rows.

--- a/docs/how-to-open-a-word-processing-document-for-read-only-access.md
+++ b/docs/how-to-open-a-word-processing-document-for-read-only-access.md
@@ -198,7 +198,7 @@ correspond to the **document**, **body**, **p**, **r**, and **t** elements.
 WordprocessingML Element|Open XML SDK 2.5 Class|Description
 --|--|--
 document|[Document](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.document.aspx) |The root element for the main document part.
-body|[Body](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.body.aspx) |The container for the block level structures such as paragraphs, tables, annotations, and others specified in the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification.
+body|[Body](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.body.aspx) |The container for the block level structures such as paragraphs, tables, annotations, and others specified in the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification.
 p|[Paragraph](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.paragraph.aspx) |A paragraph.
 r|[Run](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.run.aspx) |A run.
 t|[Text](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.text.aspx) |A range of text.

--- a/docs/how-to-open-a-word-processing-document-from-a-stream.md
+++ b/docs/how-to-open-a-word-processing-document-from-a-stream.md
@@ -114,7 +114,7 @@ correspond to the **document**, **body**, **p**, **r**, and **t** elements.
 | WordprocessingML Element | Open XML SDK 2.5 Class | Description |
 |---|---|---|
 | document | [Document](https://msdn.microsoft.com/library/office/documentformat.openxml.wordprocessing.document.aspx) | The root element for the main document part. |
-| body |Body |The container for the block-level structures such as paragraphs, tables, annotations, and others specified in the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification. |
+| body |Body |The container for the block-level structures such as paragraphs, tables, annotations, and others specified in the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification. |
 | p | [Paragraph](https://msdn.microsoft.com/library/office/documentformat.openxml.wordprocessing.body.aspx) | A paragraph. |
 | r | [Run](https://msdn.microsoft.com/library/office/documentformat.openxml.wordprocessing.paragraph.aspx) | A run. |
 | t | [Text](https://msdn.microsoft.com/library/office/documentformat.openxml.wordprocessing.text.aspx) | A range of text. |

--- a/docs/how-to-open-and-add-text-to-a-word-processing-document.md
+++ b/docs/how-to-open-and-add-text-to-a-word-processing-document.md
@@ -122,7 +122,7 @@ correspond to the **document**, **body**, **p**, **r**, and **t** elements.
 | WordprocessingML Element | Open XML SDK 2.5 Class | Description |
 |---|---|---|
 | document | [Document](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.document.aspx) | The root element for the main document part. |
-| body | [Body](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.body.aspx) | The container for the block level structures such as paragraphs, tables, annotations, and others specified in the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification. |
+| body | [Body](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.body.aspx) | The container for the block level structures such as paragraphs, tables, annotations, and others specified in the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification. |
 | p | [Paragraph](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.paragraph.aspx) | A paragraph. |
 | r | [Run](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.run.aspx) | A run. |
 | t | [Text](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.text.aspx) | A range of text. |

--- a/docs/how-to-remove-a-document-part-from-a-package.md
+++ b/docs/how-to-remove-a-document-part-from-a-package.md
@@ -35,7 +35,7 @@ this topic.
 --------------------------------------------------------------------------------
 ## Packages and Document Parts
 An Open XML document is stored as a package, whose format is defined by
-[ISO/IEC 29500-2](http://go.microsoft.com/fwlink/?LinkId=194337). The
+[ISO/IEC 29500-2](https://www.iso.org/standard/71691.html). The
 package can have multiple parts with relationships between them. The
 relationship between parts controls the category of the document. A
 document can be defined as a word-processing document if its
@@ -113,7 +113,7 @@ correspond to the **document**, **body**, **p**, **r**, and **t** elements.
 WordprocessingML Element|Open XML SDK 2.5 Class|Description
 --|--|--
 document|[Document](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.document.aspx) |The root element for the main document part.
-body|[Body](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.body.aspx) |The container for the block level structures such as paragraphs, tables, annotations, and others specified in the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification.
+body|[Body](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.body.aspx) |The container for the block level structures such as paragraphs, tables, annotations, and others specified in the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification.
 | p | [Paragraph](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.paragraph.aspx) | A paragraph. |
 | r | [Run](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.run.aspx) | A run. |
 | t | [Text](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.text.aspx) | A range of text. |
@@ -122,7 +122,7 @@ body|[Body](https://msdn.microsoft.com/en-us/library/office/documentformat.openx
 --------------------------------------------------------------------------------
 ## Settings Element
 The following text from the [ISO/IEC
-29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification
+29500](https://www.iso.org/standard/71691.html) specification
 introduces the settings element in a **PresentationML** package.
 
 > This element specifies the settings that are applied to a

--- a/docs/how-to-remove-hidden-text-from-a-word-processing-document.md
+++ b/docs/how-to-remove-hidden-text-from-a-word-processing-document.md
@@ -102,7 +102,7 @@ correspond to the **document**, **body**, **p**, **r**, and **t** elements.
 WordprocessingML Element|Open XML SDK 2.5 Class|Description
 --|--|--
 document|[Document](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.document.aspx) |The root element for the main document part.
-body|[Body](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.body.aspx) |The container for the block level structures such as paragraphs, tables, annotations and others specified in the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification.
+body|[Body](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.body.aspx) |The container for the block level structures such as paragraphs, tables, annotations and others specified in the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification.
 p|[Paragraph](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.paragraph.aspx) |A paragraph.
 r|[Run](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.run.aspx) |A run.
 t|[Text](https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.wordprocessing.text.aspx) |A range of text.
@@ -121,7 +121,7 @@ direct formatting, setting it to **true** or
 **false** sets the absolute state of the
 resulting property.
 
-The following information from the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification
+The following information from the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification
 introduces the **vanish** element.
 
 > **vanish (Hidden Text)**

--- a/docs/how-to-replace-the-header-in-a-word-processing-document.md
+++ b/docs/how-to-replace-the-header-in-a-word-processing-document.md
@@ -51,7 +51,7 @@ file and create another header part. You are also going to delete the
 reference to the existing header and create a reference to the new
 header. Therefore it is useful to familarize yourself with headers and
 the header reference element. The following information from the
-[ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337)
+[ISO/IEC 29500](https://www.iso.org/standard/71691.html)
 specification introduces the header reference element.
 
 **headerReference (Header Reference)**

--- a/docs/how-to-replace-the-theme-part-in-a-word-processing-document.md
+++ b/docs/how-to-replace-the-theme-part-in-a-word-processing-document.md
@@ -35,7 +35,7 @@ this topic.
 ## Packages and Document Parts
 
 An Open XML document is stored as a package, whose format is defined by
-[ISO/IEC 29500-2](http://go.microsoft.com/fwlink/?LinkId=194337). The
+[ISO/IEC 29500-2](https://www.iso.org/standard/71691.html). The
 package can have multiple parts with relationships between them. The
 relationship between parts controls the category of the document. A
 document can be defined as a word-processing document if its
@@ -98,7 +98,7 @@ in your computer.
 The theme element constitutes of color, font, and format schemes. In
 this how-to you learn how to change the theme programmatically.
 Therefore, it is useful to familiarize yourself with the theme element.
-The following information from the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification can
+The following information from the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification can
 be useful when working with this element.
 
 This element defines the root level complex type associated with a

--- a/docs/how-to-retrieve-comments-from-a-word-processing-document.md
+++ b/docs/how-to-retrieve-comments-from-a-word-processing-document.md
@@ -71,7 +71,7 @@ comments in a word processing file. It is important in this code example
 to familiarize yourself with those elements.
 
 The following information from the [ISO/IEC
-29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification
+29500](https://www.iso.org/standard/71691.html) specification
 introduces the comments element.
 
 > **comments (Comments Collection)**
@@ -107,7 +107,7 @@ element.
 ---------------------------------------------------------------------------------
 ## Comment Element
 The following information from the [ISO/IEC
-29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification
+29500](https://www.iso.org/standard/71691.html) specification
 introduces the comment element.
 
 > **comment (Comment Content)**

--- a/docs/how-to-search-and-replace-text-in-a-document-part.md
+++ b/docs/how-to-search-and-replace-text-in-a-document-part.md
@@ -37,7 +37,7 @@ this topic.
 --------------------------------------------------------------------------------
 ## Packages and Document Parts 
 An Open XML document is stored as a package, whose format is defined by
-[ISO/IEC 29500-2](http://go.microsoft.com/fwlink/?LinkId=194337). The
+[ISO/IEC 29500-2](https://www.iso.org/standard/71691.html). The
 package can have multiple parts with relationships between them. The
 relationship between parts controls the category of the document. A
 document can be defined as a word-processing document if its

--- a/docs/how-to-set-the-font-for-a-text-run.md
+++ b/docs/how-to-set-the-font-for-a-text-run.md
@@ -37,7 +37,7 @@ this topic.
 --------------------------------------------------------------------------------
 ## Packages and Document Parts
 An Open XML document is stored as a package, whose format is defined by
-[ISO/IEC 29500-2](http://go.microsoft.com/fwlink/?LinkId=194337). The
+[ISO/IEC 29500-2](https://www.iso.org/standard/71691.html). The
 package can have multiple parts with relationships between them. The
 relationship between parts controls the category of the document. A
 document can be defined as a word-processing document if its
@@ -89,7 +89,7 @@ long as you use using.
 --------------------------------------------------------------------------------
 ## Structure of the Run Fonts Element
 The following text from the [ISO/IEC
-29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification can
+29500](https://www.iso.org/standard/71691.html) specification can
 be useful when working with **rFonts** element.
 
 This element specifies the fonts which shall be used to display the text

--- a/docs/working-with-paragraphs.md
+++ b/docs/working-with-paragraphs.md
@@ -22,7 +22,7 @@ Open XML File Format WordprocessingML schema.
 --------------------------------------------------------------------------------
 ## Paragraphs in WordprocessingML
 The following text from the [ISO/IEC
-29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification
+29500](https://www.iso.org/standard/71691.html) specification
 introduces the Open XML WordprocessingML element used to represent a
 paragraph in a WordprocessingML document.
 

--- a/docs/working-with-runs.md
+++ b/docs/working-with-runs.md
@@ -22,7 +22,7 @@ XML File Format WordprocessingML schema.
 ---------------------------------------------------------------------------------
 ## Runs in WordprocessingML 
 The following text from the [ISO/IEC
-29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification
+29500](https://www.iso.org/standard/71691.html) specification
 introduces the Open XML WordprocessingML run element.
 
 The next level of the document hierarchy [after the paragraph] is the

--- a/docs/working-with-wordprocessingml-tables.md
+++ b/docs/working-with-wordprocessingml-tables.md
@@ -19,7 +19,7 @@ This topic discusses the Open XML SDK 2.5 [Table](https://msdn.microsoft.com/en-
 
 ## Tables in WordprocessingML
 
-The following text from the [ISO/IEC 29500](http://go.microsoft.com/fwlink/?LinkId=194337) specification introduces the Open XML WordprocessingML table element.
+The following text from the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification introduces the Open XML WordprocessingML table element.
 
 Another type of block-level content in WordprocessingML, A table is a set of paragraphs (and other block-level content) arranged in rows and columns.
 


### PR DESCRIPTION
The current URL of ISO 29500 is quite obsolete: http://go.microsoft.com/fwlink/?LinkId=194337

That URL will redirect to ISO/IEC 29500-1:2008 page. Usually, an ISO spec always get refreshed for 4 to 5 years, this means the ISO standard is not the latest based on the current status of  ISO/IEC 29500-1:2008. 

Screenshot:
![image](https://user-images.githubusercontent.com/8773147/43313507-6f3ad91e-91ba-11e8-94db-144b9dd8ca3e.png)

The latest ISO 29500 standard is now 29500-1:2016 for part 1. This PR updates the link to point to 2016 standard: https://www.iso.org/standard/71691.html

Screenshot:
![image](https://user-images.githubusercontent.com/8773147/43313568-a5343bbe-91ba-11e8-9fd5-d5edc1ad8674.png)

Currently, the page said its state is "Now".
