### PR TITLE
Adding Intl metadata localization_priority to source markdown topics

### DIFF
--- a/docs/about-the-open-xml-sdk.md
+++ b/docs/about-the-open-xml-sdk.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 
 # About the Open XML SDK 2.5 for Office

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 
 # Getting started with the Open XML SDK 2.5 for Office

--- a/docs/how-do-i.md
+++ b/docs/how-do-i.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How do I... (Open XML SDK)
 

--- a/docs/how-to-accept-all-revisions-in-a-word-processing-document.md
+++ b/docs/how-to-accept-all-revisions-in-a-word-processing-document.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 
 # How to: Accept all revisions in a word processing document (Open XML SDK)

--- a/docs/how-to-add-a-comment-to-a-slide-in-a-presentation.md
+++ b/docs/how-to-add-a-comment-to-a-slide-in-a-presentation.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 
 # How to: Add a comment to a slide in a presentation (Open XML SDK)

--- a/docs/how-to-add-a-new-document-part-that-receives-a-relationship-id-to-a-package.md
+++ b/docs/how-to-add-a-new-document-part-that-receives-a-relationship-id-to-a-package.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 
 # How to: Add a new document part that receives a relationship ID to a package

--- a/docs/how-to-add-a-new-document-part-to-a-package.md
+++ b/docs/how-to-add-a-new-document-part-to-a-package.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 
 # How to: Add a new document part to a package (Open XML SDK)

--- a/docs/how-to-add-custom-ui-to-a-spreadsheet-document.md
+++ b/docs/how-to-add-custom-ui-to-a-spreadsheet-document.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 
 # How to: Add custom UI to a spreadsheet document (Open XML SDK)

--- a/docs/how-to-add-tables-to-word-processing-documents.md
+++ b/docs/how-to-add-tables-to-word-processing-documents.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 
 # How to: Add tables to word processing documents (Open XML SDK)

--- a/docs/how-to-apply-a-style-to-a-paragraph-in-a-word-processing-document.md
+++ b/docs/how-to-apply-a-style-to-a-paragraph-in-a-word-processing-document.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 
 # How to: Apply a style to a paragraph in a word processing document

--- a/docs/how-to-apply-a-theme-to-a-presentation.md
+++ b/docs/how-to-apply-a-theme-to-a-presentation.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 
 # How to: Apply a theme to a presentation (Open XML SDK)

--- a/docs/how-to-calculate-the-sum-of-a-range-of-cells-in-a-spreadsheet-document.md
+++ b/docs/how-to-calculate-the-sum-of-a-range-of-cells-in-a-spreadsheet-document.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 
 # How to: Calculate the sum of a range of cells in a spreadsheet document

--- a/docs/how-to-change-text-in-a-table-in-a-word-processing-document.md
+++ b/docs/how-to-change-text-in-a-table-in-a-word-processing-document.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 
 # How to: Change text in a table in a word processing document (Open XML SDK)

--- a/docs/how-to-change-the-fill-color-of-a-shape-in-a-presentation.md
+++ b/docs/how-to-change-the-fill-color-of-a-shape-in-a-presentation.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 
 # How to: Change the fill color of a shape in a presentation (Open XML SDK)

--- a/docs/how-to-change-the-print-orientation-of-a-word-processing-document.md
+++ b/docs/how-to-change-the-print-orientation-of-a-word-processing-document.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 
 # How to: Change the print orientation of a word processing document

--- a/docs/how-to-convert-a-word-processing-document-from-the-docm-to-the-docx-file-format.md
+++ b/docs/how-to-convert-a-word-processing-document-from-the-docm-to-the-docx-file-format.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 
 # How to: Convert a word processing document from the DOCM to the DOCX file format

--- a/docs/how-to-copy-the-contents-of-an-open-xml-package-part-to-a-document-part-in-a-dif.md
+++ b/docs/how-to-copy-the-contents-of-an-open-xml-package-part-to-a-document-part-in-a-dif.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 
 # Copy contents of an Open XML package part to a document part in a different package

--- a/docs/how-to-create-a-package.md
+++ b/docs/how-to-create-a-package.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 
 # How to: Create a package (Open XML SDK)

--- a/docs/how-to-create-a-presentation-document-by-providing-a-file-name.md
+++ b/docs/how-to-create-a-presentation-document-by-providing-a-file-name.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How to: Create a presentation document by providing a file name (Open XML SDK)
 

--- a/docs/how-to-create-a-spreadsheet-document-by-providing-a-file-name.md
+++ b/docs/how-to-create-a-spreadsheet-document-by-providing-a-file-name.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How to: Create a spreadsheet document by providing a file name (Open XML SDK)
 

--- a/docs/how-to-create-a-word-processing-document-by-providing-a-file-name.md
+++ b/docs/how-to-create-a-word-processing-document-by-providing-a-file-name.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # Create a word processing document by providing a file name
 

--- a/docs/how-to-create-and-add-a-character-style-to-a-word-processing-document.md
+++ b/docs/how-to-create-and-add-a-character-style-to-a-word-processing-document.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # Create and add a character style to a word processing document
 

--- a/docs/how-to-create-and-add-a-paragraph-style-to-a-word-processing-document.md
+++ b/docs/how-to-create-and-add-a-paragraph-style-to-a-word-processing-document.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # Create and add a paragraph style to a word processing document
 

--- a/docs/how-to-delete-a-slide-from-a-presentation.md
+++ b/docs/how-to-delete-a-slide-from-a-presentation.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # How to: Delete a slide from a presentation (Open XML SDK)
 

--- a/docs/how-to-delete-all-the-comments-by-an-author-from-all-the-slides-in-a-presentatio.md
+++ b/docs/how-to-delete-all-the-comments-by-an-author-from-all-the-slides-in-a-presentatio.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # Delete all the comments by an author from all the slides in a presentation
 

--- a/docs/how-to-delete-comments-by-all-or-a-specific-author-in-a-word-processing-document.md
+++ b/docs/how-to-delete-comments-by-all-or-a-specific-author-in-a-word-processing-document.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # How to: Delete comments by all or a specific author in a word processing document (Open XML SDK)
 

--- a/docs/how-to-delete-text-from-a-cell-in-a-spreadsheet.md
+++ b/docs/how-to-delete-text-from-a-cell-in-a-spreadsheet.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How to: Delete text from a cell in a spreadsheet document (Open XML SDK)
 

--- a/docs/how-to-extract-styles-from-a-word-processing-document.md
+++ b/docs/how-to-extract-styles-from-a-word-processing-document.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # How to: Extract styles from a word processing document (Open XML SDK)
 

--- a/docs/how-to-get-a-column-heading-in-a-spreadsheet.md
+++ b/docs/how-to-get-a-column-heading-in-a-spreadsheet.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How to: Get a column heading in a spreadsheet document (Open XML SDK)
 

--- a/docs/how-to-get-all-the-external-hyperlinks-in-a-presentation.md
+++ b/docs/how-to-get-all-the-external-hyperlinks-in-a-presentation.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # How to: Get all the external hyperlinks in a presentation (Open XML SDK)
 

--- a/docs/how-to-get-all-the-text-in-a-slide-in-a-presentation.md
+++ b/docs/how-to-get-all-the-text-in-a-slide-in-a-presentation.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # How to: Get all the text in a slide in a presentation (Open XML SDK)
 

--- a/docs/how-to-get-all-the-text-in-all-slides-in-a-presentation.md
+++ b/docs/how-to-get-all-the-text-in-all-slides-in-a-presentation.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # How to: Get all the text in all slides in a presentation (Open XML SDK)
 

--- a/docs/how-to-get-the-contents-of-a-document-part-from-a-package.md
+++ b/docs/how-to-get-the-contents-of-a-document-part-from-a-package.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How to: Get the contents of a document part from a package (Open XML SDK)
 

--- a/docs/how-to-get-the-titles-of-all-the-slides-in-a-presentation.md
+++ b/docs/how-to-get-the-titles-of-all-the-slides-in-a-presentation.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # How to: Get the titles of all the slides in a presentation (Open XML SDK)
 

--- a/docs/how-to-get-worksheet-information-from-a-package.md
+++ b/docs/how-to-get-worksheet-information-from-a-package.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How to: Get worksheet information from an Open XML package (Open XML SDK)
 

--- a/docs/how-to-insert-a-chart-into-a-spreadsheet.md
+++ b/docs/how-to-insert-a-chart-into-a-spreadsheet.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How to: Insert a chart into a spreadsheet document (Open XML SDK)
 

--- a/docs/how-to-insert-a-comment-into-a-word-processing-document.md
+++ b/docs/how-to-insert-a-comment-into-a-word-processing-document.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # How to: Insert a comment into a word processing document (Open XML SDK)
 

--- a/docs/how-to-insert-a-new-slide-into-a-presentation.md
+++ b/docs/how-to-insert-a-new-slide-into-a-presentation.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How to: Insert a new slide into a presentation (Open XML SDK)
 

--- a/docs/how-to-insert-a-new-worksheet-into-a-spreadsheet.md
+++ b/docs/how-to-insert-a-new-worksheet-into-a-spreadsheet.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How to: Insert a new worksheet into a spreadsheet document (Open XML SDK)
 

--- a/docs/how-to-insert-a-picture-into-a-word-processing-document.md
+++ b/docs/how-to-insert-a-picture-into-a-word-processing-document.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How to: Insert a picture into a word processing document (Open XML SDK)
 

--- a/docs/how-to-insert-a-table-into-a-word-processing-document.md
+++ b/docs/how-to-insert-a-table-into-a-word-processing-document.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How to: Insert a table into a word processing document (Open XML SDK)
 

--- a/docs/how-to-insert-text-into-a-cell-in-a-spreadsheet.md
+++ b/docs/how-to-insert-text-into-a-cell-in-a-spreadsheet.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How to: Insert text into a cell in a spreadsheet document (Open XML SDK)
 

--- a/docs/how-to-merge-two-adjacent-cells-in-a-spreadsheet.md
+++ b/docs/how-to-merge-two-adjacent-cells-in-a-spreadsheet.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How to: Merge two adjacent cells in a spreadsheet document (Open XML SDK)
 

--- a/docs/how-to-move-a-paragraph-from-one-presentation-to-another.md
+++ b/docs/how-to-move-a-paragraph-from-one-presentation-to-another.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # How to: Move a paragraph from one presentation to another (Open XML SDK)
 

--- a/docs/how-to-move-a-slide-to-a-new-position-in-a-presentation.md
+++ b/docs/how-to-move-a-slide-to-a-new-position-in-a-presentation.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # How to: Move a slide to a new position in a presentation (Open XML SDK)
 

--- a/docs/how-to-open-a-presentation-document-for-read-only-access.md
+++ b/docs/how-to-open-a-presentation-document-for-read-only-access.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # How to: Open a presentation document for read-only access (Open XML SDK)
 

--- a/docs/how-to-open-a-spreadsheet-document-for-read-only-access.md
+++ b/docs/how-to-open-a-spreadsheet-document-for-read-only-access.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How to: Open a spreadsheet document for read-only access (Open XML SDK)
 

--- a/docs/how-to-open-a-spreadsheet-document-from-a-stream.md
+++ b/docs/how-to-open-a-spreadsheet-document-from-a-stream.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How to: Open a spreadsheet document from a stream (Open XML SDK)
 

--- a/docs/how-to-open-a-word-processing-document-for-read-only-access.md
+++ b/docs/how-to-open-a-word-processing-document-for-read-only-access.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How to: Open a word processing document for read-only access (Open XML SDK)
 

--- a/docs/how-to-open-a-word-processing-document-from-a-stream.md
+++ b/docs/how-to-open-a-word-processing-document-from-a-stream.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How to: Open a word processing document from a stream (Open XML SDK)
 

--- a/docs/how-to-open-and-add-text-to-a-word-processing-document.md
+++ b/docs/how-to-open-and-add-text-to-a-word-processing-document.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How to: Open and add text to a word processing document (Open XML SDK)
 

--- a/docs/how-to-parse-and-read-a-large-spreadsheet.md
+++ b/docs/how-to-parse-and-read-a-large-spreadsheet.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How to: Parse and read a large spreadsheet document (Open XML SDK)
 

--- a/docs/how-to-remove-a-document-part-from-a-package.md
+++ b/docs/how-to-remove-a-document-part-from-a-package.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # How to: Remove a document part from a package (Open XML SDK)
 

--- a/docs/how-to-remove-hidden-text-from-a-word-processing-document.md
+++ b/docs/how-to-remove-hidden-text-from-a-word-processing-document.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # How to: Remove hidden text from a word processing document (Open XML SDK)
 

--- a/docs/how-to-remove-the-headers-and-footers-from-a-word-processing-document.md
+++ b/docs/how-to-remove-the-headers-and-footers-from-a-word-processing-document.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # How to: Remove the headers and footers from a word processing document (Open XML SDK)
 

--- a/docs/how-to-replace-the-header-in-a-word-processing-document.md
+++ b/docs/how-to-replace-the-header-in-a-word-processing-document.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How to: Replace the header in a word processing document (Open XML SDK)
 

--- a/docs/how-to-replace-the-styles-parts-in-a-word-processing-document.md
+++ b/docs/how-to-replace-the-styles-parts-in-a-word-processing-document.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # How to: Replace the styles parts in a word processing document (Open XML SDK)
 

--- a/docs/how-to-replace-the-theme-part-in-a-word-processing-document.md
+++ b/docs/how-to-replace-the-theme-part-in-a-word-processing-document.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # How to: Replace the theme part in a word processing document (Open XML SDK)
 

--- a/docs/how-to-retrieve-a-dictionary-of-all-named-ranges-in-a-spreadsheet.md
+++ b/docs/how-to-retrieve-a-dictionary-of-all-named-ranges-in-a-spreadsheet.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # How to: Retrieve a dictionary of all named ranges in a spreadsheet document (Open XML SDK)
 

--- a/docs/how-to-retrieve-a-list-of-the-hidden-rows-or-columns-in-a-spreadsheet.md
+++ b/docs/how-to-retrieve-a-list-of-the-hidden-rows-or-columns-in-a-spreadsheet.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How to: Retrieve a list of the hidden rows or columns in a spreadsheet document (Open XML SDK)
 

--- a/docs/how-to-retrieve-a-list-of-the-hidden-worksheets-in-a-spreadsheet.md
+++ b/docs/how-to-retrieve-a-list-of-the-hidden-worksheets-in-a-spreadsheet.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # How to: Retrieve a list of the hidden worksheets in a spreadsheet document (Open XML SDK)
 

--- a/docs/how-to-retrieve-a-list-of-the-worksheets-in-a-spreadsheet.md
+++ b/docs/how-to-retrieve-a-list-of-the-worksheets-in-a-spreadsheet.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How to: Retrieve a list of the worksheets in a spreadsheet document (Open XML SDK)
 

--- a/docs/how-to-retrieve-application-property-values-from-a-word-processing-document.md
+++ b/docs/how-to-retrieve-application-property-values-from-a-word-processing-document.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # How to: Retrieve application property values from a word processing document (Open XML SDK)
 

--- a/docs/how-to-retrieve-comments-from-a-word-processing-document.md
+++ b/docs/how-to-retrieve-comments-from-a-word-processing-document.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # How to: Retrieve comments from a word processing document (Open XML SDK)
 

--- a/docs/how-to-retrieve-the-number-of-slides-in-a-presentation-document.md
+++ b/docs/how-to-retrieve-the-number-of-slides-in-a-presentation-document.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # How to: Retrieve the number of slides in a presentation document (Open XML SDK)
 

--- a/docs/how-to-retrieve-the-values-of-cells-in-a-spreadsheet.md
+++ b/docs/how-to-retrieve-the-values-of-cells-in-a-spreadsheet.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How to: Retrieve the values of cells in a spreadsheet document (Open XML SDK)
 

--- a/docs/how-to-search-and-replace-text-in-a-document-part.md
+++ b/docs/how-to-search-and-replace-text-in-a-document-part.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How to: Search and replace text in a document part (Open XML SDK)
 

--- a/docs/how-to-set-a-custom-property-in-a-word-processing-document.md
+++ b/docs/how-to-set-a-custom-property-in-a-word-processing-document.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How to: Set a custom property in a word processing document (Open XML SDK)
 

--- a/docs/how-to-set-the-font-for-a-text-run.md
+++ b/docs/how-to-set-the-font-for-a-text-run.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How to: Set the font for a text run (Open XML SDK)
 

--- a/docs/how-to-validate-a-word-processing-document.md
+++ b/docs/how-to-validate-a-word-processing-document.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # How to: Validate a word processing document (Open XML SDK)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,4 @@
 ---
 redirect_url: /office/open-xml/open-xml-sdk/
+localization_priority: Normal
 ---

--- a/docs/introduction-to-markup-compatibility.md
+++ b/docs/introduction-to-markup-compatibility.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # Introduction to markup compatibility (Open XML SDK)
 

--- a/docs/open-xml-sdk-design-considerations.md
+++ b/docs/open-xml-sdk-design-considerations.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # Open XML SDK 2.5 for Office design considerations
 

--- a/docs/open-xml-sdk.md
+++ b/docs/open-xml-sdk.md
@@ -15,6 +15,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 
 # Welcome to the Open XML SDK 2.5 for Office

--- a/docs/packages-and-general.md
+++ b/docs/packages-and-general.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # Packages and general (Open XML SDK)
 

--- a/docs/presentations.md
+++ b/docs/presentations.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # Presentations (Open XML SDK)
 

--- a/docs/spreadsheets.md
+++ b/docs/spreadsheets.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # Spreadsheets (Open XML SDK)
 

--- a/docs/structure-of-a-presentationml-document.md
+++ b/docs/structure-of-a-presentationml-document.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # Structure of a PresentationML document (Open XML SDK)
 

--- a/docs/structure-of-a-spreadsheetml-document.md
+++ b/docs/structure-of-a-spreadsheetml-document.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # Structure of a SpreadsheetML document (Open XML SDK)
 

--- a/docs/structure-of-a-wordprocessingml-document.md
+++ b/docs/structure-of-a-wordprocessingml-document.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # Structure of a WordprocessingML document (Open XML SDK)
 

--- a/docs/understanding-the-open-xml-file-formats.md
+++ b/docs/understanding-the-open-xml-file-formats.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # Understanding the Open XML file formats
 

--- a/docs/what-s-new-in-the-open-xml-sdk.md
+++ b/docs/what-s-new-in-the-open-xml-sdk.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 
 # What's new in the Open XML SDK 2.5 for Office

--- a/docs/word-processing.md
+++ b/docs/word-processing.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # Word processing (Open XML SDK)
 

--- a/docs/working-with-animation.md
+++ b/docs/working-with-animation.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # Working with animation (Open XML SDK)
 

--- a/docs/working-with-comments.md
+++ b/docs/working-with-comments.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # Working with comments (Open XML SDK)
 

--- a/docs/working-with-conditional-formatting.md
+++ b/docs/working-with-conditional-formatting.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # Working with conditional formatting (Open XML SDK)
 

--- a/docs/working-with-formulas.md
+++ b/docs/working-with-formulas.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # Working with formulas (Open XML SDK)
 

--- a/docs/working-with-handout-master-slides.md
+++ b/docs/working-with-handout-master-slides.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # Working with handout master slides (Open XML SDK)
 

--- a/docs/working-with-notes-slides.md
+++ b/docs/working-with-notes-slides.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # Working with notes slides (Open XML SDK)
 

--- a/docs/working-with-paragraphs.md
+++ b/docs/working-with-paragraphs.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # Working with paragraphs (Open XML SDK)
 

--- a/docs/working-with-pivottables.md
+++ b/docs/working-with-pivottables.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # Working with PivotTables (Open XML SDK)
 

--- a/docs/working-with-presentation-slides.md
+++ b/docs/working-with-presentation-slides.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # Working with presentation slides (Open XML SDK)
 

--- a/docs/working-with-presentationml-documents.md
+++ b/docs/working-with-presentationml-documents.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # Working with PresentationML documents (Open XML SDK)
 

--- a/docs/working-with-presentations.md
+++ b/docs/working-with-presentations.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # Working with presentations (Open XML SDK)
 

--- a/docs/working-with-runs.md
+++ b/docs/working-with-runs.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # Working with runs (Open XML SDK)
 

--- a/docs/working-with-sheets.md
+++ b/docs/working-with-sheets.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # Working with sheets (Open XML SDK)
 

--- a/docs/working-with-slide-layouts.md
+++ b/docs/working-with-slide-layouts.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # Working with slide layouts (Open XML SDK)
 

--- a/docs/working-with-slide-masters.md
+++ b/docs/working-with-slide-masters.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Normal
 ---
 # Working with slide masters (Open XML SDK)
 

--- a/docs/working-with-spreadsheetml-documents.md
+++ b/docs/working-with-spreadsheetml-documents.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # Working with SpreadsheetML documents (Open XML SDK)
 

--- a/docs/working-with-tables.md
+++ b/docs/working-with-tables.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # Working with SpreadsheetML tables (Open XML SDK)
 

--- a/docs/working-with-the-calculation-chain.md
+++ b/docs/working-with-the-calculation-chain.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # Working with the calculation chain (Open XML SDK)
 

--- a/docs/working-with-the-shared-string-table.md
+++ b/docs/working-with-the-shared-string-table.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # Working with the shared string table (Open XML SDK)
 

--- a/docs/working-with-wordprocessingml-documents.md
+++ b/docs/working-with-wordprocessingml-documents.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # Working with WordprocessingML documents (Open XML SDK)
 

--- a/docs/working-with-wordprocessingml-tables.md
+++ b/docs/working-with-wordprocessingml-tables.md
@@ -12,6 +12,7 @@ ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
 ms.date: 11/01/2017
+localization_priority: Priority
 ---
 # Working with WordprocessingML tables (Open XML SDK)
 


### PR DESCRIPTION
Submitted by Office Intl team to apply metadata localization_priority to source markdown topics.

Contact GSXCON-Tech if you have questions.
