### PR TITLE
Move slide to first position bug

### DIFF
--- a/docs/how-to-move-a-slide-to-a-new-position-in-a-presentation.md
+++ b/docs/how-to-move-a-slide-to-a-new-position-in-a-presentation.md
@@ -348,7 +348,7 @@ source slide) is identified.
     {
         targetSlide = null;
     }
-    if (from < to)
+    else if (from < to)
     {
         targetSlide = slideIdList.ChildElements[to] as SlideId;
     }
@@ -374,8 +374,7 @@ source slide) is identified.
     ' Identify the position of the target slide after which to move the source slide.
     If to = 0 Then
         targetSlide = Nothing
-    End If
-    If From < to Then
+    ElseIf From < to Then
         targetSlide = TryCast(slideIdList.ChildElements(to), SlideId)
     Else
         targetSlide = TryCast(slideIdList.ChildElements(to - 1), SlideId)
@@ -514,7 +513,7 @@ Following is the complete sample code in both C\# and Visual Basic.
         {
             targetSlide = null;
         }
-        if (from < to)
+        else if (from < to)
         {
             targetSlide = slideIdList.ChildElements[to] as SlideId;
         }
@@ -616,9 +615,7 @@ Following is the complete sample code in both C\# and Visual Basic.
         ' Identify the position of the target slide after which to move the source slide.
         If (moveTo = 0) Then
             targetSlide = Nothing
-        End If
-
-        If (from < moveTo) Then
+        ElseIf (from < moveTo) Then
             targetSlide = CType(slideIdList.ChildElements(moveTo), SlideId)
         Else
             targetSlide = CType(slideIdList.ChildElements((moveTo - 1)), SlideId)


### PR DESCRIPTION
Updated a bug that caused an exception to be thrown when moving a slide to the first position.
There was code to check if the to position was 0. If so it sets the targetSlide to null.
The next section checks if the from position is less than the to position (which it is obviously not) and the else block of this is executed which tries to get the slide prior to the to position. In this case there is no slide prior to the to position and we get an index out of range exception.
I have added an else before the second if. From reading the code this is what the initial author must have meant to do as currently the initial if (to == 0) is pointless.

I did not try to compile the VB code after the change and I am not familiar with VB so please double check the syntax.