### PR TITLE
Adds a note about modern add-ins

### DIFF
--- a/docs/about-the-open-xml-sdk.md
+++ b/docs/about-the-open-xml-sdk.md
@@ -19,7 +19,7 @@ localization_priority: Priority
 
 Open XML is an open standard for word-processing documents, presentations, and spreadsheets that can be freely implemented by multiple applications on different platforms. Open XML is designed to faithfully represent existing word-processing documents, presentations, and spreadsheets that are encoded in binary formats defined by Microsoft Office applications. The reason for Open XML is simple: billions of documents now exist but, unfortunately, the information in those documents is tightly coupled with the programs that created them. The purpose of the Open XML standard is to de-couple documents created by Microsoft Office applications so that they can be manipulated by other applications independent of proprietary formats and without the loss of data.
 
-[!include[Add-ins note](../includes/addinsnote.md)]
+[!include[Add-ins note](./includes/addinsnote.md)]
 
 ## Structure of an Open XML Package
 

--- a/docs/about-the-open-xml-sdk.md
+++ b/docs/about-the-open-xml-sdk.md
@@ -19,6 +19,7 @@ localization_priority: Priority
 
 Open XML is an open standard for word-processing documents, presentations, and spreadsheets that can be freely implemented by multiple applications on different platforms. Open XML is designed to faithfully represent existing word-processing documents, presentations, and spreadsheets that are encoded in binary formats defined by Microsoft Office applications. The reason for Open XML is simple: billions of documents now exist but, unfortunately, the information in those documents is tightly coupled with the programs that created them. The purpose of the Open XML standard is to de-couple documents created by Microsoft Office applications so that they can be manipulated by other applications independent of proprietary formats and without the loss of data.
 
+[!include[Addins note](../includes/addinsnote.md)]
 
 ## Structure of an Open XML Package
 

--- a/docs/about-the-open-xml-sdk.md
+++ b/docs/about-the-open-xml-sdk.md
@@ -19,7 +19,7 @@ localization_priority: Priority
 
 Open XML is an open standard for word-processing documents, presentations, and spreadsheets that can be freely implemented by multiple applications on different platforms. Open XML is designed to faithfully represent existing word-processing documents, presentations, and spreadsheets that are encoded in binary formats defined by Microsoft Office applications. The reason for Open XML is simple: billions of documents now exist but, unfortunately, the information in those documents is tightly coupled with the programs that created them. The purpose of the Open XML standard is to de-couple documents created by Microsoft Office applications so that they can be manipulated by other applications independent of proprietary formats and without the loss of data.
 
-[!include[Addins note](../includes/addinsnote.md)]
+[!include[Add-ins note](../includes/addinsnote.md)]
 
 ## Structure of an Open XML Package
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,7 +19,7 @@ localization_priority: Priority
 
 The Open XML SDK 2.5 for Office simplifies the task of manipulating Open XML packages and the underlying Open XML schema elements within a package. The classes in the Open XML SDK 2.5 encapsulate many common tasks that developers perform on Open XML packages, so that you can perform complex operations with just a few lines of code.
 
-[!include[Add-ins note](../includes/addinsnote.md)]
+[!include[Add-ins note](./includes/addinsnote.md)]
 
 ------------------------------------------------------------
 ## Using the Classes in the Open XML SDK

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,7 +19,7 @@ localization_priority: Priority
 
 The Open XML SDK 2.5 for Office simplifies the task of manipulating Open XML packages and the underlying Open XML schema elements within a package. The classes in the Open XML SDK 2.5 encapsulate many common tasks that developers perform on Open XML packages, so that you can perform complex operations with just a few lines of code.
 
-[!include[Addins note](../includes/addinsnote.md)]
+[!include[Add-ins note](../includes/addinsnote.md)]
 
 ------------------------------------------------------------
 ## Using the Classes in the Open XML SDK

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,6 +19,7 @@ localization_priority: Priority
 
 The Open XML SDK 2.5 for Office simplifies the task of manipulating Open XML packages and the underlying Open XML schema elements within a package. The classes in the Open XML SDK 2.5 encapsulate many common tasks that developers perform on Open XML packages, so that you can perform complex operations with just a few lines of code.
 
+[!include[Addins note](../includes/addinsnote.md)]
 
 ------------------------------------------------------------
 ## Using the Classes in the Open XML SDK

--- a/docs/how-do-i.md
+++ b/docs/how-do-i.md
@@ -19,6 +19,7 @@ localization_priority: Priority
 This section provides how-to topics for working with the Open XML SDK
 2.5 for Office.
 
+[!include[Add-ins note](../includes/addinsnote.md)]
 
 ## In this section
 

--- a/docs/how-do-i.md
+++ b/docs/how-do-i.md
@@ -19,7 +19,7 @@ localization_priority: Priority
 This section provides how-to topics for working with the Open XML SDK
 2.5 for Office.
 
-[!include[Add-ins note](../includes/addinsnote.md)]
+[!include[Add-ins note](./includes/addinsnote.md)]
 
 ## In this section
 

--- a/docs/how-to-parse-and-read-a-large-spreadsheet.md
+++ b/docs/how-to-parse-and-read-a-large-spreadsheet.md
@@ -20,7 +20,7 @@ This topic shows how to use the classes in the Open XML SDK 2.5 for
 Office to programmatically read a large Excel file. For more information
 about the basic structure of a **SpreadsheetML** document, see [Structure of a SpreadsheetML document (Open XML SDK)](structure-of-a-spreadsheetml-document.md).
 
-[!include[Add-ins note](../includes/addinsnote.md)]
+[!include[Add-ins note](./includes/addinsnote.md)]
 
 You must use the following **using** directives
 or **Imports** statements to compile the code

--- a/docs/how-to-parse-and-read-a-large-spreadsheet.md
+++ b/docs/how-to-parse-and-read-a-large-spreadsheet.md
@@ -20,7 +20,7 @@ This topic shows how to use the classes in the Open XML SDK 2.5 for
 Office to programmatically read a large Excel file. For more information
 about the basic structure of a **SpreadsheetML** document, see [Structure of a SpreadsheetML document (Open XML SDK)](structure-of-a-spreadsheetml-document.md).
 
-[!include[Addins note](../includes/addinsnote.md)]
+[!include[Add-ins note](../includes/addinsnote.md)]
 
 You must use the following **using** directives
 or **Imports** statements to compile the code

--- a/docs/how-to-parse-and-read-a-large-spreadsheet.md
+++ b/docs/how-to-parse-and-read-a-large-spreadsheet.md
@@ -20,6 +20,8 @@ This topic shows how to use the classes in the Open XML SDK 2.5 for
 Office to programmatically read a large Excel file. For more information
 about the basic structure of a **SpreadsheetML** document, see [Structure of a SpreadsheetML document (Open XML SDK)](structure-of-a-spreadsheetml-document.md).
 
+[!include[Addins note](../includes/addinsnote.md)]
+
 You must use the following **using** directives
 or **Imports** statements to compile the code
 in this topic.

--- a/docs/includes/addinsnote.md
+++ b/docs/includes/addinsnote.md
@@ -1,0 +1,2 @@
+> [!NOTE]
+> Interested in developing solutions that extend the Office experience across [multiple platforms](https://dev.office.com/add-in-availability)? Check out the new [Office Add-ins model](https://dev.office.com/docs/add-ins/overview/office-add-ins). Office Add-ins have a small footprint compared to VSTO Add-ins and solutions, and you can build them by using almost any web programming technology, such as HTML5, JavaScript, CSS3, and XML.

--- a/docs/open-xml-sdk.md
+++ b/docs/open-xml-sdk.md
@@ -41,7 +41,7 @@ with just a few lines of code.
 
 Portions of ISO/IEC 29500:2008<sup>1</sup> are referenced in the SDK.
 
-[!include[Addins note](../includes/addinsnote.md)]
+[!include[Add-ins note](../includes/addinsnote.md)]
 
 ## In this section 
 

--- a/docs/open-xml-sdk.md
+++ b/docs/open-xml-sdk.md
@@ -41,6 +41,7 @@ with just a few lines of code.
 
 Portions of ISO/IEC 29500:2008<sup>1</sup> are referenced in the SDK.
 
+[!include[Addins note](../includes/addinsnote.md)]
 
 ## In this section 
 

--- a/docs/open-xml-sdk.md
+++ b/docs/open-xml-sdk.md
@@ -41,7 +41,7 @@ with just a few lines of code.
 
 Portions of ISO/IEC 29500:2008<sup>1</sup> are referenced in the SDK.
 
-[!include[Add-ins note](../includes/addinsnote.md)]
+[!include[Add-ins note](./includes/addinsnote.md)]
 
 ## In this section 
 

--- a/docs/structure-of-a-spreadsheetml-document.md
+++ b/docs/structure-of-a-spreadsheetml-document.md
@@ -26,7 +26,7 @@ spreadsheet document. In addition, a spreadsheet document might contain
 \<**table**\>, \<**chartsheet**\>, \<**pivotTableDefinition**\>, or other spreadsheet
 related elements.
 
-[!include[Add-ins note](../includes/addinsnote.md)]
+[!include[Add-ins note](./includes/addinsnote.md)]
 
 --------------------------------------------------------------------------------
 ## Important Spreadsheet Parts

--- a/docs/structure-of-a-spreadsheetml-document.md
+++ b/docs/structure-of-a-spreadsheetml-document.md
@@ -26,6 +26,7 @@ spreadsheet document. In addition, a spreadsheet document might contain
 \<**table**\>, \<**chartsheet**\>, \<**pivotTableDefinition**\>, or other spreadsheet
 related elements.
 
+[!include[Addins note](../includes/addinsnote.md)]
 
 --------------------------------------------------------------------------------
 ## Important Spreadsheet Parts

--- a/docs/structure-of-a-spreadsheetml-document.md
+++ b/docs/structure-of-a-spreadsheetml-document.md
@@ -26,7 +26,7 @@ spreadsheet document. In addition, a spreadsheet document might contain
 \<**table**\>, \<**chartsheet**\>, \<**pivotTableDefinition**\>, or other spreadsheet
 related elements.
 
-[!include[Addins note](../includes/addinsnote.md)]
+[!include[Add-ins note](../includes/addinsnote.md)]
 
 --------------------------------------------------------------------------------
 ## Important Spreadsheet Parts


### PR DESCRIPTION
I work on the docs for Office Add-ins (https://github.com/OfficeDev/office-js-docs-pr) and by studying web analytics data, we think that adding a note to select high-trafficked pages of this docset will drive customers to a more modern add-ins solution, if they want that. Data from our customer surveys and interviews show that most people who have used previous versions of related Office technology do not discover the modern Office Add-in docs, so we are trying to drive discoverability. Happy to answer more questions on this if you have them. 