### PR TITLE
Line 419: Null Reference Exception on empty cells

### DIFF
--- a/docs/how-to-retrieve-the-values-of-cells-in-a-spreadsheet.md
+++ b/docs/how-to-retrieve-the-values-of-cells-in-a-spreadsheet.md
@@ -416,7 +416,7 @@ code sample in C\# and Visual Basic.
               Where(c => c.CellReference == addressName).FirstOrDefault();
 
             // If the cell does not exist, return an empty string.
-            if (theCell != null)
+            if (theCell.InnerText.Length > 0)
             {
                 value = theCell.InnerText;
 


### PR DESCRIPTION
I used the old code ("theCell != null") and got null reference exceptions when cells were empty. 

I found that theCell.InnerText.Length>0 avoided the null reference exception. Using Object.ReferenceEquals(), or !(x== null) didn't change the outcome.