### PR TITLE
Fixes a bug with getting comment ids

### DIFF
--- a/docs/how-to-insert-a-comment-into-a-word-processing-document.md
+++ b/docs/how-to-insert-a-comment-into-a-word-processing-document.md
@@ -278,7 +278,7 @@ Following is the complete sample code in both C\# and Visual Basic.
                 if (comments.HasChildren)
                 {
                     // Obtain an unused ID.
-                    id = comments.Descendants<Comment>().Select(e => e.Id.Value).Max();
+                    id = (comments.Descendants<Comment>().Select(e => int.Parse(e.Id.Value)).Max() + 1).ToString();
                 }
             }
             else


### PR DESCRIPTION
The current code returns "0" for every comment id, corrupting the comments in the Word document. This change fixes the code to match the intended behavior of obtaining an unused comment id.