### PR TITLE
Update how-to-insert-a-picture-into-a-word-processing-document.md

### DIFF
--- a/docs/how-to-insert-a-picture-into-a-word-processing-document.md
+++ b/docs/how-to-insert-a-picture-into-a-word-processing-document.md
@@ -185,7 +185,7 @@ Then, append the reference to the body. The element should be in a [Run](https:/
                                  new A.PresetGeometry(
                                      new A.AdjustValueList()
                                  ) { Preset = A.ShapeTypeValues.Rectangle }))
-                     ) { Uri = "https://schemas.openxmlformats.org/drawingml/2006/picture" })
+                     ) { Uri = "http://schemas.openxmlformats.org/drawingml/2006/picture" })
              )
              {
                  DistanceFromTop = (UInt32Value)0U,


### PR DESCRIPTION
The current code contains a bug that makes the document not open in MS Word. This single error (`https` instead of `http` in URI) causes the document to be unopenable in any tested Word product (Word for Office 365 Win/macOS/iOS, MS Word Professional 2016).

Interestingly it does open fine in LibreOffice and others.