### PR TITLE
rem metadata from topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open XML documentation
 
-This repo is the source markdown for documentation published at https://docs.microsoft.com/office/open-xml/open-xml-sdk.
+This repo is the source markdown for documentation published at /office/open-xml/open-xml-sdk.md.
 
 ## Contributing
 

--- a/docs/about-the-open-xml-sdk.md
+++ b/docs/about-the-open-xml-sdk.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 620e86b5-49f2-43dc-85d4-9c7456c09552
 title: About the Open XML SDK 2.5 for Office
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 7b729dda-bbb6-437e-93d6-7bfe7b8183fa
 title: Getting started with the Open XML SDK 2.5 for Office</td>
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-do-i.md
+++ b/docs/how-do-i.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: b5cc0e8d-da79-482a-81fa-f18c18d29f6c
 title: How do I... (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-accept-all-revisions-in-a-word-processing-document.md
+++ b/docs/how-to-accept-all-revisions-in-a-word-processing-document.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: b3406fcc-f10b-4075-a18f-116400f35faf
 title: 'How to: Accept all revisions in a word processing document (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-accept-all-revisions-in-a-word-processing-document.md
+++ b/docs/how-to-accept-all-revisions-in-a-word-processing-document.md
@@ -511,6 +511,6 @@ The following is the complete sample code in both C\# and Visual Basic.
 
 ## See also
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)
 - [Accepting Revisions in Open XML Word-Processing Documents](https://docs.microsoft.com/previous-versions/office/developer/office-2007/ee836138(v=office.12))
 

--- a/docs/how-to-accept-all-revisions-in-a-word-processing-document.md
+++ b/docs/how-to-accept-all-revisions-in-a-word-processing-document.md
@@ -1,17 +1,16 @@
 ---
-
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
 - schema
 ms.assetid: b3406fcc-f10b-4075-a18f-116400f35faf
 title: 'How to: Accept all revisions in a word processing document (Open XML SDK)'
+description: 'Learn how to accept all revisions in a word processing document using the Open XML SDK.'
 ms.suite: office
-
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual
-ms.date: 11/01/2017
+ms.date: 06/30/2021
 localization_priority: Priority
 ---
 
@@ -56,7 +55,6 @@ To open an existing document, you can instantiate the [WordprocessingDocument](h
 
 The **using** statement provides a recommended alternative to the typical .Open, .Save, .Close sequence. It ensures that the **Dispose** method (internal method used by the Open XML SDK to clean up resources) is automatically called when the closing brace is reached. The block that follows the **using** statement establishes a scope for the object that is created or named in the **using** statement, in this case *wdDoc*. Because the **WordprocessingDocument** class in the Open XML SDK automatically saves and closes the object as part of its **System.IDisposable** implementation, and because **Dispose** is automatically called when you exit the block, you do not have to explicitly call **Save** and **Close** as long as you use **using**.
 
-
 ## Structure of a WordProcessingML Document
 
 The basic document structure of a **WordProcessingML** document consists of the **document** and **body** elements, followed by one or more block level elements such as **p**, which represents a paragraph. A paragraph contains one or more **r** elements. The **r** stands for run, which is a region of text with a common set of properties, such as formatting. A run contains one or more **t** elements. The **t** element contains a range of text. The following code example shows the **WordprocessingML** markup for a document that contains the text "Example text."
@@ -89,15 +87,15 @@ When you accept a revision mark, you change the properties of a paragraph either
 
 The following information from the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification introduces the **ParagraphPropertiesChange** element (**pPrChange**).
 
-**pPrChange (Revision Information for Paragraph Properties)**
+### *pPrChange (Revision Information for Paragraph Properties)
 
 This element specifies the details about a single revision to a set of paragraph properties in a WordprocessingML document.
 
 This element stores this revision as follows:
 
--   The child element of this element contains the complete set of paragraph properties which were applied to this paragraph before this revision.
+- The child element of this element contains the complete set of paragraph properties which were applied to this paragraph before this revision.
 
--   The attributes of this element contain information about when this revision took place (in other words, when these properties became a "former" set of paragraph properties).
+- The attributes of this element contain information about when this revision took place (in other words, when these properties became a "former" set of paragraph properties).
 
 Consider a paragraph in a WordprocessingML document which is centered, and this change in the paragraph properties is tracked as a revision. This revision would be specified using the following WordprocessingML markup.
 
@@ -114,13 +112,12 @@ The element specifies that there was a revision to the paragraph properties at 0
 
 © ISO/IEC29500: 2008.
 
-
 ## Deleted Element
 
 The following information from the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification
 introduces the Deleted element (**del**).
 
-**del (Deleted Paragraph)**
+### del (Deleted Paragraph)
 
 This element specifies that the paragraph mark delimiting the end of a paragraph within a WordprocessingML document shall be treated as deleted (in other words, the contents of this paragraph are no longer delimited by this paragraph mark, and are combined with the following paragraph—but those contents shall not automatically be marked as deleted) as part of a tracked revision.
 
@@ -155,13 +152,12 @@ and this deletion was tracked as a revision.
 
 © ISO/IEC29500: 2008.
 
-
 ## The Inserted Element
 
 The following information from the [ISO/IEC 29500](https://www.iso.org/standard/71691.html) specification
 introduces the Inserted element (**ins**).
 
-**ins (Inserted Table Row)**
+### ins (Inserted Table Row)
 
 This element specifies that the parent table row shall be treated as an
 inserted row whose insertion has been tracked as a revision. This
@@ -202,7 +198,6 @@ specifies that this row was inserted, and this insertion was tracked as
 a revision.
 
 © ISO/IEC29500: 2008.
-
 
 ## How the Sample Code Works
 
@@ -513,4 +508,3 @@ The following is the complete sample code in both C\# and Visual Basic.
 
 - [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)
 - [Accepting Revisions in Open XML Word-Processing Documents](https://docs.microsoft.com/previous-versions/office/developer/office-2007/ee836138(v=office.12))
-

--- a/docs/how-to-add-a-comment-to-a-slide-in-a-presentation.md
+++ b/docs/how-to-add-a-comment-to-a-slide-in-a-presentation.md
@@ -760,6 +760,6 @@ comment string to the first slide in the presentation file Myppt1.pptx.
 
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)
 
 

--- a/docs/how-to-add-a-comment-to-a-slide-in-a-presentation.md
+++ b/docs/how-to-add-a-comment-to-a-slide-in-a-presentation.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 403abe97-7ab2-40ba-92c0-d6312a6d10c8
 title: 'How to: Add a comment to a slide in a presentation (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-add-a-new-document-part-that-receives-a-relationship-id-to-a-package.md
+++ b/docs/how-to-add-a-new-document-part-that-receives-a-relationship-id-to-a-package.md
@@ -301,6 +301,6 @@ The following is the complete code example in both C\# and Visual Basic.
 ## See also 
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)
 
 

--- a/docs/how-to-add-a-new-document-part-that-receives-a-relationship-id-to-a-package.md
+++ b/docs/how-to-add-a-new-document-part-that-receives-a-relationship-id-to-a-package.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: c9b2ce55-548c-4443-8d2e-08fe1f06b7d7
 title: 'How to: Add a new document part that receives a relationship ID to a package'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-add-a-new-document-part-to-a-package.md
+++ b/docs/how-to-add-a-new-document-part-to-a-package.md
@@ -210,7 +210,7 @@ Following is the complete code example in both C\# and Visual Basic.
 ## See also 
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)
 
 
 

--- a/docs/how-to-add-a-new-document-part-to-a-package.md
+++ b/docs/how-to-add-a-new-document-part-to-a-package.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: ec83a076-9d71-49d1-915f-e7090f74c13a
 title: 'How to: Add a new document part to a package (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-add-custom-ui-to-a-spreadsheet-document.md
+++ b/docs/how-to-add-custom-ui-to-a-spreadsheet-document.md
@@ -306,7 +306,7 @@ code sample in C\# and Visual Basic.
 ## See also 
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)
 - [Ribbon Designer](https://msdn.microsoft.com/library/26617206-f4da-416f-a18a-d817b2d4872d(Office.15).aspx)
 - [Walkthrough: Creating a Custom Tab by Using the Ribbon Designer](https://msdn.microsoft.com/library/312865e6-950f-46ab-88de-fe7eb8036bfe(Office.15).aspx)
 

--- a/docs/how-to-add-custom-ui-to-a-spreadsheet-document.md
+++ b/docs/how-to-add-custom-ui-to-a-spreadsheet-document.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: fdb29547-c295-4e7d-9fc5-d86d8d8c2967
 title: 'How to: Add custom UI to a spreadsheet document (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-add-tables-to-word-processing-documents.md
+++ b/docs/how-to-add-tables-to-word-processing-documents.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -8,7 +8,7 @@ ms.assetid: 65c377d2-1763-4bb6-8915-bc6839ccf62d
 title: 'How to: Add tables to word processing documents (Open XML SDK)'
 description: 'Learn how to add tables to word processing documents using the Open XML SDK.'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-apply-a-style-to-a-paragraph-in-a-word-processing-document.md
+++ b/docs/how-to-apply-a-style-to-a-paragraph-in-a-word-processing-document.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -8,7 +8,7 @@ ms.assetid: 8d465a77-6c1b-453a-8375-ecf80d2f1bdc
 title: 'How to: Apply a style to a paragraph in a word processing document'
 description: 'Learn how to apply a style to a paragraph in a word processing document using the Open XML SDK.'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-apply-a-theme-to-a-presentation.md
+++ b/docs/how-to-apply-a-theme-to-a-presentation.md
@@ -674,7 +674,7 @@ would see the same theme of the file Myppt9-theme.pptx.
 ## See also
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)
 
 
 

--- a/docs/how-to-apply-a-theme-to-a-presentation.md
+++ b/docs/how-to-apply-a-theme-to-a-presentation.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: d7575014-8187-4e55-bafa-15bc317bf8c8
 title: 'How to: Apply a theme to a presentation (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-calculate-the-sum-of-a-range-of-cells-in-a-spreadsheet-document.md
+++ b/docs/how-to-calculate-the-sum-of-a-range-of-cells-in-a-spreadsheet-document.md
@@ -928,7 +928,7 @@ The following is the complete sample code in both C\# and Visual Basic.
 -----------------------------------------------------------------------------
 ## See also 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)
 - [Language-Integrated Query (LINQ)](https://msdn.microsoft.com/library/bb397926.aspx)
 - [Lambda Expressions](https://msdn.microsoft.com/library/bb531253.aspx)
 - [Lambda Expressions (C\# Programming Guide)](https://msdn.microsoft.com/library/bb397687.aspx)

--- a/docs/how-to-calculate-the-sum-of-a-range-of-cells-in-a-spreadsheet-document.md
+++ b/docs/how-to-calculate-the-sum-of-a-range-of-cells-in-a-spreadsheet-document.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 41c001da-204e-4669-a722-76c9f7928281
 title: 'How to: Calculate the sum of a range of cells in a spreadsheet document'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-change-text-in-a-table-in-a-word-processing-document.md
+++ b/docs/how-to-change-text-in-a-table-in-a-word-processing-document.md
@@ -275,7 +275,7 @@ Following is the complete code example.
 
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)
 
 [How to: Change Text in a Table in a Word Processing Document](https://msdn.microsoft.com/library/documentformat.openxml.wordprocessing.table(office.14).aspx)
 

--- a/docs/how-to-change-text-in-a-table-in-a-word-processing-document.md
+++ b/docs/how-to-change-text-in-a-table-in-a-word-processing-document.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 69f7c94e-2b8c-4bec-be8c-31933e2ee042
 title: 'How to: Change text in a table in a word processing document (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-change-the-fill-color-of-a-shape-in-a-presentation.md
+++ b/docs/how-to-change-the-fill-color-of-a-shape-in-a-presentation.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: e3adae2b-c7e8-45f4-b1fc-93d937f4b3b1
 title: 'How to: Change the fill color of a shape in a presentation (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-change-the-fill-color-of-a-shape-in-a-presentation.md
+++ b/docs/how-to-change-the-fill-color-of-a-shape-in-a-presentation.md
@@ -347,7 +347,7 @@ change in the fill color.
 
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)
 
 
 

--- a/docs/how-to-change-the-print-orientation-of-a-word-processing-document.md
+++ b/docs/how-to-change-the-print-orientation-of-a-word-processing-document.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -8,7 +8,7 @@ ms.assetid: bb5319c8-ee99-4862-937b-94dcae8deaca
 title: 'How to: Change the print orientation of a word processing document (Open XML SDK)'
 description: 'Learn how to change the print orientation of a word processing document using the Open XML SDK.'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-convert-a-word-processing-document-from-the-docm-to-the-docx-file-format.md
+++ b/docs/how-to-convert-a-word-processing-document-from-the-docm-to-the-docx-file-format.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -9,7 +9,7 @@ title: 'How to: Convert a word processing document from the DOCM to the DOCX fil
 description: 'Learn how to convert a word processing document from the DOCM to the DOCX file format using the Open XML SDK.'
 
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-copy-the-contents-of-an-open-xml-package-part-to-a-document-part-in-a-dif.md
+++ b/docs/how-to-copy-the-contents-of-an-open-xml-package-part-to-a-document-part-in-a-dif.md
@@ -276,7 +276,7 @@ Following is the complete sample code in both C\# and Visual Basic.
 ## See also
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)
 
 
 

--- a/docs/how-to-copy-the-contents-of-an-open-xml-package-part-to-a-document-part-in-a-dif.md
+++ b/docs/how-to-copy-the-contents-of-an-open-xml-package-part-to-a-document-part-in-a-dif.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 7dbfd93c-a9e3-4465-9b57-4a043b07b807
 title: 'Copy contents of an Open XML package part to a document part in a different package'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-create-a-package.md
+++ b/docs/how-to-create-a-package.md
@@ -311,7 +311,7 @@ Following is the complete sample code in both C\# and Visual Basic.
 
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)
 
 
 

--- a/docs/how-to-create-a-package.md
+++ b/docs/how-to-create-a-package.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: fe261589-7b04-47df-8ee9-26b444e587b0
 title: 'How to: Create a package (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-create-a-presentation-document-by-providing-a-file-name.md
+++ b/docs/how-to-create-a-presentation-document-by-providing-a-file-name.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -8,7 +8,7 @@ ms.assetid: 3d4a800e-64f0-4715-919f-a8f7d92a5c37
 title: 'How to: Create a presentation document by providing a file name (Open XML SDK)'
 description: 'Learn how to create a presentation document by providing a file name using the Open XML SDK.'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-create-a-spreadsheet-document-by-providing-a-file-name.md
+++ b/docs/how-to-create-a-spreadsheet-document-by-providing-a-file-name.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 03ac59c4-49a6-4721-8931-d045c4c9ddde
 title: 'How to: Create a spreadsheet document by providing a file name (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-create-a-spreadsheet-document-by-providing-a-file-name.md
+++ b/docs/how-to-create-a-spreadsheet-document-by-providing-a-file-name.md
@@ -237,4 +237,4 @@ Following is the complete sample code in both C\# and Visual Basic.
 ## See also 
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)

--- a/docs/how-to-create-a-word-processing-document-by-providing-a-file-name.md
+++ b/docs/how-to-create-a-word-processing-document-by-providing-a-file-name.md
@@ -223,4 +223,4 @@ Following is the complete code example in both C\# and Visual Basic.
 ## See also
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)

--- a/docs/how-to-create-a-word-processing-document-by-providing-a-file-name.md
+++ b/docs/how-to-create-a-word-processing-document-by-providing-a-file-name.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 1771fc05-dd94-40e3-a788-6a13809d64f3
 title: 'Create a word processing document by providing a file name'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-create-and-add-a-character-style-to-a-word-processing-document.md
+++ b/docs/how-to-create-and-add-a-character-style-to-a-word-processing-document.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -8,7 +8,7 @@ ms.assetid: c38f2c94-f0b5-4bb5-8c95-02e556d4e9f1
 title: 'Create and add a character style to a word processing document'
 description: 'Learn how to create and add a character style to a word processing document using the Open XML SDK.'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-create-and-add-a-paragraph-style-to-a-word-processing-document.md
+++ b/docs/how-to-create-and-add-a-paragraph-style-to-a-word-processing-document.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -8,7 +8,7 @@ ms.assetid: 73cbca2d-3603-45a5-8a73-c2e718376b01
 title: 'How to: Create and add a paragraph style to a word processing document (Open XML SDK)'
 description: 'Learn how to create and add a paragraph style to a word processing document using hte Open XML SDK.'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-delete-a-slide-from-a-presentation.md
+++ b/docs/how-to-delete-a-slide-from-a-presentation.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 98781b17-8de4-46e9-b29a-5b4033665491
 title: 'How to: Delete a slide from a presentation (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-delete-a-slide-from-a-presentation.md
+++ b/docs/how-to-delete-a-slide-from-a-presentation.md
@@ -755,4 +755,4 @@ Following is the complete sample code in both C\# and Visual Basic.
 
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)

--- a/docs/how-to-delete-all-the-comments-by-an-author-from-all-the-slides-in-a-presentatio.md
+++ b/docs/how-to-delete-all-the-comments-by-an-author-from-all-the-slides-in-a-presentatio.md
@@ -443,4 +443,4 @@ The following is the complete sample code in both C\# and Visual Basic.
 
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)

--- a/docs/how-to-delete-all-the-comments-by-an-author-from-all-the-slides-in-a-presentatio.md
+++ b/docs/how-to-delete-all-the-comments-by-an-author-from-all-the-slides-in-a-presentatio.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 3b892a6a-2972-461e-94a9-0a1ede854bda
 title: 'Delete all the comments by an author from all the slides in a presentation'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-delete-comments-by-all-or-a-specific-author-in-a-word-processing-document.md
+++ b/docs/how-to-delete-comments-by-all-or-a-specific-author-in-a-word-processing-document.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -8,7 +8,7 @@ ms.assetid: c66a64ca-cb0d-4acc-9d05-535b5bbb8c96
 title: 'How to: Delete comments by all or a specific author in a word processing document (Open XML SDK)'
 description: 'Learn how to delete comments by all or a specific author in a word processing document using the Open XML SDK.'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-delete-text-from-a-cell-in-a-spreadsheet.md
+++ b/docs/how-to-delete-text-from-a-cell-in-a-spreadsheet.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 4b395c48-b469-4d69-b229-d4bad3f3dd8b
 title: 'How to: Delete text from a cell in a spreadsheet document (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-delete-text-from-a-cell-in-a-spreadsheet.md
+++ b/docs/how-to-delete-text-from-a-cell-in-a-spreadsheet.md
@@ -631,7 +631,7 @@ The following is the complete code sample in both C\# and Visual Basic.
 ## See also
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)  
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)  
 
 [Language-Integrated Query (LINQ)](https://msdn.microsoft.com/library/bb397926.aspx)  
 

--- a/docs/how-to-extract-styles-from-a-word-processing-document.md
+++ b/docs/how-to-extract-styles-from-a-word-processing-document.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -8,7 +8,7 @@ ms.assetid: 20258c39-9411-41f2-8463-e94a4b0fa326
 title: 'How to: Extract styles from a word processing document (Open XML SDK)'
 description: 'Learn how to extract styles from a word processing document using the Open XML SDK.'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-get-a-column-heading-in-a-spreadsheet.md
+++ b/docs/how-to-get-a-column-heading-in-a-spreadsheet.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 56ba8cee-d789-4a03-b8ff-b161af0788ff
 title: 'How to: Get a column heading in a spreadsheet document (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-get-a-column-heading-in-a-spreadsheet.md
+++ b/docs/how-to-get-a-column-heading-in-a-spreadsheet.md
@@ -410,7 +410,7 @@ Following is the complete sample code in both C\# and Visual Basic.
 
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)  
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)  
 
 [Language-Integrated Query (LINQ)](https://msdn.microsoft.com/library/bb397926.aspx)  
 

--- a/docs/how-to-get-all-the-external-hyperlinks-in-a-presentation.md
+++ b/docs/how-to-get-all-the-external-hyperlinks-in-a-presentation.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: d6daf04e-3e45-4570-a184-8f0449c7ab91
 title: 'How to: Get all the external hyperlinks in a presentation (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-get-all-the-external-hyperlinks-in-a-presentation.md
+++ b/docs/how-to-get-all-the-external-hyperlinks-in-a-presentation.md
@@ -356,4 +356,4 @@ get the list of URIs in your presentation.
 ## See also
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)

--- a/docs/how-to-get-all-the-text-in-a-slide-in-a-presentation.md
+++ b/docs/how-to-get-all-the-text-in-a-slide-in-a-presentation.md
@@ -631,4 +631,4 @@ Following is the complete sample code in both C\# and Visual Basic.
 ## See also
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)

--- a/docs/how-to-get-all-the-text-in-a-slide-in-a-presentation.md
+++ b/docs/how-to-get-all-the-text-in-a-slide-in-a-presentation.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 6de46612-f864-413f-a504-11ea85f1f88f
 title: 'How to: Get all the text in a slide in a presentation (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-get-all-the-text-in-all-slides-in-a-presentation.md
+++ b/docs/how-to-get-all-the-text-in-all-slides-in-a-presentation.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: debad542-5915-45ad-a71c-eeb95b40ec1a
 title: 'How to: Get all the text in all slides in a presentation (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-get-the-contents-of-a-document-part-from-a-package.md
+++ b/docs/how-to-get-the-contents-of-a-document-part-from-a-package.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: b0d3d890-431a-4838-89dc-1f0dccd5dcd0
 title: 'How to: Get the contents of a document part from a package (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-get-the-titles-of-all-the-slides-in-a-presentation.md
+++ b/docs/how-to-get-the-titles-of-all-the-slides-in-a-presentation.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: b7d5d1fd-dcdf-4f88-9d57-884562c8144f
 title: 'How to: Get the titles of all the slides in a presentation (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-get-worksheet-information-from-a-package.md
+++ b/docs/how-to-get-worksheet-information-from-a-package.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 124cb0a0-cc47-433f-bad0-06b793890650
 title: 'How to: Get worksheet information from an Open XML package (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-insert-a-chart-into-a-spreadsheet.md
+++ b/docs/how-to-insert-a-chart-into-a-spreadsheet.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 281776d0-be75-46eb-8fdc-a1f656291175
 title: 'How to: Insert a chart into a spreadsheet document (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-insert-a-chart-into-a-spreadsheet.md
+++ b/docs/how-to-insert-a-chart-into-a-spreadsheet.md
@@ -883,7 +883,7 @@ The following is the complete sample code in both C\# and Visual Basic.
 
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)
 
 [Language-Integrated Query (LINQ)](https://msdn.microsoft.com/library/bb397926.aspx)
 

--- a/docs/how-to-insert-a-comment-into-a-word-processing-document.md
+++ b/docs/how-to-insert-a-comment-into-a-word-processing-document.md
@@ -364,7 +364,7 @@ Following is the complete sample code in both C\# and Visual Basic.
 ## See also
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)
 
 [Language-Integrated Query (LINQ)](https://msdn.microsoft.com/library/bb397926.aspx)
 

--- a/docs/how-to-insert-a-comment-into-a-word-processing-document.md
+++ b/docs/how-to-insert-a-comment-into-a-word-processing-document.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 474f0a6c-62c8-4f04-b3f9-cd613a6e48d0
 title: 'How to: Insert a comment into a word processing document (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-insert-a-new-slide-into-a-presentation.md
+++ b/docs/how-to-insert-a-new-slide-into-a-presentation.md
@@ -749,4 +749,4 @@ The following is the complete sample code in both C\# and Visual Basic.
 
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)

--- a/docs/how-to-insert-a-new-slide-into-a-presentation.md
+++ b/docs/how-to-insert-a-new-slide-into-a-presentation.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 6079a1ae-4567-4d99-b350-b819fd06fe5c
 title: 'How to: Insert a new slide into a presentation (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-insert-a-new-worksheet-into-a-spreadsheet.md
+++ b/docs/how-to-insert-a-new-worksheet-into-a-spreadsheet.md
@@ -296,7 +296,7 @@ Following is the complete sample code in both C\# and Visual Basic.
 ## See also 
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)
 
 [Language-Integrated Query (LINQ)](https://msdn.microsoft.com/library/bb397926.aspx)
 

--- a/docs/how-to-insert-a-new-worksheet-into-a-spreadsheet.md
+++ b/docs/how-to-insert-a-new-worksheet-into-a-spreadsheet.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 944036fa-9251-408f-86cb-2351a5f8cd48
 title: 'How to: Insert a new worksheet into a spreadsheet document (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-insert-a-picture-into-a-word-processing-document.md
+++ b/docs/how-to-insert-a-picture-into-a-word-processing-document.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -8,7 +8,7 @@ ms.assetid: ae8c98d9-dd11-4b75-804c-165095d60ffd
 title: 'How to: Insert a picture into a word processing document (Open XML SDK)'
 description: 'Learn how to insert a picture into a word processing document using the Open XML SDK.'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-insert-a-table-into-a-word-processing-document.md
+++ b/docs/how-to-insert-a-table-into-a-word-processing-document.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 9d390cf8-1654-4a75-b3b8-4aba86ed1476
 title: 'How to: Insert a table into a word processing document (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-insert-a-table-into-a-word-processing-document.md
+++ b/docs/how-to-insert-a-table-into-a-word-processing-document.md
@@ -399,7 +399,7 @@ Following is the complete sample code in both C\# and Visual Basic.
 
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)
 
 [Object Initializers: Named and Anonymous Types (Visual Basic .NET)](https://msdn.microsoft.com/library/bb385125.aspx)
 

--- a/docs/how-to-insert-text-into-a-cell-in-a-spreadsheet.md
+++ b/docs/how-to-insert-text-into-a-cell-in-a-spreadsheet.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 5ded6212-e8d4-4206-9025-cb5991bd2f80
 title: 'How to: Insert text into a cell in a spreadsheet document (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-insert-text-into-a-cell-in-a-spreadsheet.md
+++ b/docs/how-to-insert-text-into-a-cell-in-a-spreadsheet.md
@@ -762,7 +762,7 @@ The following is the complete sample code in both C\# and Visual Basic.
 ## See also
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)
 
 [Language-Integrated Query (LINQ)](https://msdn.microsoft.com/library/bb397926.aspx)
 

--- a/docs/how-to-merge-two-adjacent-cells-in-a-spreadsheet.md
+++ b/docs/how-to-merge-two-adjacent-cells-in-a-spreadsheet.md
@@ -583,7 +583,7 @@ The following is the complete sample code in both C\# and Visual Basic.
 
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)
 
 [Language-Integrated Query (LINQ)](https://msdn.microsoft.com/library/bb397926.aspx)
 

--- a/docs/how-to-merge-two-adjacent-cells-in-a-spreadsheet.md
+++ b/docs/how-to-merge-two-adjacent-cells-in-a-spreadsheet.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 73747a65-0857-4fd4-8362-3613f4169203
 title: 'How to: Merge two adjacent cells in a spreadsheet document (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-move-a-paragraph-from-one-presentation-to-another.md
+++ b/docs/how-to-move-a-paragraph-from-one-presentation-to-another.md
@@ -479,4 +479,4 @@ The following is the complete sample code in both C\# and Visual Basic.
 
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)

--- a/docs/how-to-move-a-paragraph-from-one-presentation-to-another.md
+++ b/docs/how-to-move-a-paragraph-from-one-presentation-to-another.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: ef817bef-27cd-4c2a-acf3-b7bba17e6e1e
 title: 'How to: Move a paragraph from one presentation to another (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-move-a-slide-to-a-new-position-in-a-presentation.md
+++ b/docs/how-to-move-a-slide-to-a-new-position-in-a-presentation.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 95fd9dcd-41e9-4e83-9191-2f3110ae73d5
 title: 'How to: Move a slide to a new position in a presentation (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-move-a-slide-to-a-new-position-in-a-presentation.md
+++ b/docs/how-to-move-a-slide-to-a-new-position-in-a-presentation.md
@@ -637,4 +637,4 @@ Following is the complete sample code in both C\# and Visual Basic.
 ## See also
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)

--- a/docs/how-to-open-a-presentation-document-for-read-only-access.md
+++ b/docs/how-to-open-a-presentation-document-for-read-only-access.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 8dc8a6ac-aa9e-47cc-b45e-e128fcec3c57
 title: 'How to: Open a presentation document for read-only access (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-open-a-presentation-document-for-read-only-access.md
+++ b/docs/how-to-open-a-presentation-document-for-read-only-access.md
@@ -379,4 +379,4 @@ The following is the complete code listing in C\# and Visual Basic.
 
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)

--- a/docs/how-to-open-a-spreadsheet-document-for-read-only-access.md
+++ b/docs/how-to-open-a-spreadsheet-document-for-read-only-access.md
@@ -302,4 +302,4 @@ The following is the complete sample code in both C\# and Visual Basic.
 ## See also
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)

--- a/docs/how-to-open-a-spreadsheet-document-for-read-only-access.md
+++ b/docs/how-to-open-a-spreadsheet-document-for-read-only-access.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 625bf571-5630-47f8-953f-e9e1a93e3229
 title: 'How to: Open a spreadsheet document for read-only access (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-open-a-spreadsheet-document-from-a-stream.md
+++ b/docs/how-to-open-a-spreadsheet-document-from-a-stream.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 7fde676b-81b6-4210-82bf-f74d0d925dec
 title: 'How to: Open a spreadsheet document from a stream (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-open-a-spreadsheet-document-from-a-stream.md
+++ b/docs/how-to-open-a-spreadsheet-document-from-a-stream.md
@@ -280,4 +280,4 @@ The following is the complete sample code in both C\# and Visual Basic.
 ## See also 
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)

--- a/docs/how-to-open-a-word-processing-document-for-read-only-access.md
+++ b/docs/how-to-open-a-word-processing-document-for-read-only-access.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: c811c2c7-1066-45a5-a724-33d0fbfd5284
 title: 'How to: Open a word processing document for read-only access (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-open-a-word-processing-document-for-read-only-access.md
+++ b/docs/how-to-open-a-word-processing-document-for-read-only-access.md
@@ -359,4 +359,4 @@ The following is the complete sample code in C\# and VB.
 ## See also 
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)

--- a/docs/how-to-open-a-word-processing-document-from-a-stream.md
+++ b/docs/how-to-open-a-word-processing-document-from-a-stream.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 75cff172-b29d-475a-8eb5-d8e90642f015
 title: 'How to: Open a word processing document from a stream (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-open-a-word-processing-document-from-a-stream.md
+++ b/docs/how-to-open-a-word-processing-document-from-a-stream.md
@@ -233,4 +233,4 @@ Following is the complete sample code in both C\# and Visual Basic.
 
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)

--- a/docs/how-to-open-and-add-text-to-a-word-processing-document.md
+++ b/docs/how-to-open-and-add-text-to-a-word-processing-document.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 360318b5-9d17-42a1-b707-c3ccd1a89c97
 title: 'How to: Open and add text to a word processing document (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-open-and-add-text-to-a-word-processing-document.md
+++ b/docs/how-to-open-and-add-text-to-a-word-processing-document.md
@@ -222,4 +222,4 @@ of **OpenSettings**.
 ## See also
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)

--- a/docs/how-to-parse-and-read-a-large-spreadsheet.md
+++ b/docs/how-to-parse-and-read-a-large-spreadsheet.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: dd28d239-42be-42a9-893e-b65338fe184e
 title: 'How to: Parse and read a large spreadsheet document (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-parse-and-read-a-large-spreadsheet.md
+++ b/docs/how-to-parse-and-read-a-large-spreadsheet.md
@@ -282,4 +282,4 @@ The following is the complete code sample in both C\# and Visual Basic.
 
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)

--- a/docs/how-to-remove-a-document-part-from-a-package.md
+++ b/docs/how-to-remove-a-document-part-from-a-package.md
@@ -221,4 +221,4 @@ Following is the complete code example in both C\# and Visual Basic.
 ## See also
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)

--- a/docs/how-to-remove-a-document-part-from-a-package.md
+++ b/docs/how-to-remove-a-document-part-from-a-package.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: b3890e64-51d1-4643-8d07-2c9d8e060000
 title: 'How to: Remove a document part from a package (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-remove-hidden-text-from-a-word-processing-document.md
+++ b/docs/how-to-remove-hidden-text-from-a-word-processing-document.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: e5e9c6ba-b422-4639-bb8c-6da521307f13
 title: 'How to: Remove hidden text from a word processing document (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-remove-hidden-text-from-a-word-processing-document.md
+++ b/docs/how-to-remove-hidden-text-from-a-word-processing-document.md
@@ -262,4 +262,4 @@ Following is the complete sample code in both C\# and Visual Basic.
 ## See also
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)

--- a/docs/how-to-remove-the-headers-and-footers-from-a-word-processing-document.md
+++ b/docs/how-to-remove-the-headers-and-footers-from-a-word-processing-document.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -8,7 +8,7 @@ ms.assetid: 22f973f4-58d1-4dd4-943e-a15ac2571b7c
 title: 'How to: Remove the headers and footers from a word processing document (Open XML SDK)'
 description: 'Learn how to remove the headers and footers from a word processing document using the Open XML SDK.'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-replace-the-header-in-a-word-processing-document.md
+++ b/docs/how-to-replace-the-header-in-a-word-processing-document.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -8,7 +8,7 @@ ms.assetid: d57e9b7d-b271-4c8d-998f-b7ca3eb6c850
 title: 'How to: Replace the header in a word processing document (Open XML SDK)'
 description: 'Learn how to replace the header in a word processing document using the Open XML SDK.'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-replace-the-styles-parts-in-a-word-processing-document.md
+++ b/docs/how-to-replace-the-styles-parts-in-a-word-processing-document.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -8,7 +8,7 @@ ms.assetid: 67edb37c-cfec-461c-b616-5a8b7d074c91
 title: 'How to: Replace the styles parts in a word processing document (Open XML SDK)'
 description: 'Learn how to replace the styles parts in a word processing document using the Open XML SDK.'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-replace-the-theme-part-in-a-word-processing-document.md
+++ b/docs/how-to-replace-the-theme-part-in-a-word-processing-document.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: cfb75725-f3a7-43c0-85f4-7bb4c3f448ca
 title: 'How to: Replace the theme part in a word processing document (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-replace-the-theme-part-in-a-word-processing-document.md
+++ b/docs/how-to-replace-the-theme-part-in-a-word-processing-document.md
@@ -289,4 +289,4 @@ Following is the complete sample code in both C\# and Visual Basic.
 
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)

--- a/docs/how-to-retrieve-a-dictionary-of-all-named-ranges-in-a-spreadsheet.md
+++ b/docs/how-to-retrieve-a-dictionary-of-all-named-ranges-in-a-spreadsheet.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -8,7 +8,7 @@ ms.assetid: 0aa2aef3-b329-4ccc-8f25-9660c083e14e
 title: 'How to: Retrieve a dictionary of all named ranges in a spreadsheet document (Open XML SDK)'
 description: 'Learn how to retrieve a dictionary of all named ranges in a spreadsheet document using the Open XML SDK.'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-retrieve-a-list-of-the-hidden-rows-or-columns-in-a-spreadsheet.md
+++ b/docs/how-to-retrieve-a-list-of-the-hidden-rows-or-columns-in-a-spreadsheet.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -8,7 +8,7 @@ ms.assetid: 5adddb6e-545e-4fba-ae35-cc4682e3eda7
 title: 'How to: Retrieve a list of the hidden rows or columns in a spreadsheet document (Open XML SDK)'
 description: 'Learn how to retrieve a list of the hidden rows or columns in a spreadsheet document using the Open XML SDK.'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-retrieve-a-list-of-the-hidden-worksheets-in-a-spreadsheet.md
+++ b/docs/how-to-retrieve-a-list-of-the-hidden-worksheets-in-a-spreadsheet.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -8,7 +8,7 @@ ms.assetid: a6d35b76-d12a-460c-9d9d-2334abde759e
 title: 'How to: Retrieve a list of the hidden worksheets in a spreadsheet document (Open XML SDK)'
 description: 'Learn how to retrieve a list of the hidden worksheets in a spreadsheet document using the Open XML SDK.'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-retrieve-a-list-of-the-worksheets-in-a-spreadsheet.md
+++ b/docs/how-to-retrieve-a-list-of-the-worksheets-in-a-spreadsheet.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -8,7 +8,7 @@ ms.assetid: a0c1e144-2080-4470-bd4b-ed98f1399374
 title: 'How to: Retrieve a list of the worksheets in a spreadsheet document (Open XML SDK)'
 description: 'Learn how to retrieve a list of the worksheets in a spreadsheet document using the Open XML SDK.'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-retrieve-application-property-values-from-a-word-processing-document.md
+++ b/docs/how-to-retrieve-application-property-values-from-a-word-processing-document.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -8,7 +8,7 @@ ms.assetid: 3e9ca812-460e-442e-8257-38f523a53dc6
 title: 'How to: Retrieve application property values from a word processing document (Open XML SDK)'
 description: 'Learn how to retrieve application property values from a word processing document using the Open XML SDK.'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-retrieve-comments-from-a-word-processing-document.md
+++ b/docs/how-to-retrieve-comments-from-a-word-processing-document.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 70839c86-36ef-4b67-a682-abd5114b2bfe
 title: 'How to: Retrieve comments from a word processing document (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-retrieve-comments-from-a-word-processing-document.md
+++ b/docs/how-to-retrieve-comments-from-a-word-processing-document.md
@@ -238,4 +238,4 @@ The following is the complete sample code in both C\# and Visual Basic.
 ## See also
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)

--- a/docs/how-to-retrieve-the-number-of-slides-in-a-presentation-document.md
+++ b/docs/how-to-retrieve-the-number-of-slides-in-a-presentation-document.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -8,7 +8,7 @@ ms.assetid: b6f429a7-4489-4155-b713-2139f3add8c2
 title: 'How to: Retrieve the number of slides in a presentation document (Open XML SDK)'
 description: 'Learn how to retrieve the number of slides in a presentation document using the Open XML SDK.'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-retrieve-the-values-of-cells-in-a-spreadsheet.md
+++ b/docs/how-to-retrieve-the-values-of-cells-in-a-spreadsheet.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -8,7 +8,7 @@ ms.assetid: 15e26fbd-fc23-466a-a7cc-b7584ba8f821
 title: 'How to: Retrieve the values of cells in a spreadsheet document (Open XML SDK)'
 description: 'Learn how to retrieve the values of cells in a spreadsheet document using the Open XML SDK.'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-search-and-replace-text-in-a-document-part.md
+++ b/docs/how-to-search-and-replace-text-in-a-document-part.md
@@ -199,6 +199,6 @@ The following is the complete sample code in both C\# and Visual Basic.
 ## See also 
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)
 
 [Regular Expressions](https://msdn.microsoft.com/library/hs600312.aspx)

--- a/docs/how-to-search-and-replace-text-in-a-document-part.md
+++ b/docs/how-to-search-and-replace-text-in-a-document-part.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: cbb4547e-45fa-48ee-872e-8727beec6dfa
 title: 'How to: Search and replace text in a document part (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-set-a-custom-property-in-a-word-processing-document.md
+++ b/docs/how-to-set-a-custom-property-in-a-word-processing-document.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -8,7 +8,7 @@ ms.assetid: how-to-set-a-custom-property-in-a-word-processing-document
 title: 'How to: Set a custom property in a word processing document (Open XML SDK)'
 description: 'Learn how to use the classes in the Open XML SDK 2.5 for Office to programmatically set a custom property in a word processing document.'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-set-the-font-for-a-text-run.md
+++ b/docs/how-to-set-the-font-for-a-text-run.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: e4e5a2e5-a97e-47b9-a263-6723bd4230a1
 title: 'How to: Set the font for a text run (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/how-to-set-the-font-for-a-text-run.md
+++ b/docs/how-to-set-the-font-for-a-text-run.md
@@ -269,7 +269,7 @@ The following is the complete sample code in both C\# and Visual Basic.
 ## See also
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)
 
 [Object Initializers: Named and Anonymous Types](https://msdn.microsoft.com/library/bb385125.aspx)
 

--- a/docs/how-to-validate-a-word-processing-document.md
+++ b/docs/how-to-validate-a-word-processing-document.md
@@ -219,4 +219,4 @@ Following is the complete sample code in both C\# and Visual Basic.
 ## See also
 
 
-- [Open XML SDK 2.5 class library reference](https://docs.microsoft.com/office/open-xml/open-xml-sdk)
+- [Open XML SDK 2.5 class library reference](/office/open-xml/open-xml-sdk.md)

--- a/docs/how-to-validate-a-word-processing-document.md
+++ b/docs/how-to-validate-a-word-processing-document.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: a20bf30b-204e-4c57-8ca3-badf4b0b3e03
 title: 'How to: Validate a word processing document (Open XML SDK)'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/introduction-to-markup-compatibility.md
+++ b/docs/introduction-to-markup-compatibility.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: dd42a9a3-5c16-4cab-ad6d-506cf822ec7a
 title: Introduction to markup compatibility (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/open-xml-sdk-design-considerations.md
+++ b/docs/open-xml-sdk-design-considerations.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 43c49a6d-96b5-4e87-a5bf-01629d61aad4
 title: Open XML SDK 2.5 for Office design considerations
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/open-xml-sdk.md
+++ b/docs/open-xml-sdk.md
@@ -2,7 +2,7 @@
 keywords: system.io.packaging
 f1_keywords:
 - system.io.packaging
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -11,7 +11,7 @@ ms.assetid: f6a9ae68-7989-4208-97f5-3c945137a0ab
 title: Welcome to the Open XML SDK 2.5 for Office
 description: 'Documentation and guidance for the strongly-typed classes in the Open XML SDK 2.5 for Office.'
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/packages-and-general.md
+++ b/docs/packages-and-general.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: edbe267a-ced9-43fd-a702-fd0165cb3438
 title: Packages and general (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/presentations.md
+++ b/docs/presentations.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 0a81a7fb-c431-4f53-a199-e72eea91f360
 title: Presentations (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/spreadsheets.md
+++ b/docs/spreadsheets.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 7808dcc4-8f50-42c4-bad1-d69fe5f045fe
 title: Spreadsheets (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/structure-of-a-presentationml-document.md
+++ b/docs/structure-of-a-presentationml-document.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: fe780fcd-ed8f-4ee1-938e-cf3bb358ccae
 title: Structure of a PresentationML document (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/structure-of-a-spreadsheetml-document.md
+++ b/docs/structure-of-a-spreadsheetml-document.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 3b35a153-c8ff-4dc7-96d5-02c515f31770
 title: Structure of a SpreadsheetML document (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/structure-of-a-wordprocessingml-document.md
+++ b/docs/structure-of-a-wordprocessingml-document.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 03636fa2-be44-4e8d-9c26-7d38415bb459
 title: Structure of a WordprocessingML document (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/understanding-the-open-xml-file-formats.md
+++ b/docs/understanding-the-open-xml-file-formats.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: ada81388-9ed2-43f4-ab2c-2bb82f711e90
 title: Understanding the Open XML file formats
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/what-s-new-in-the-open-xml-sdk.md
+++ b/docs/what-s-new-in-the-open-xml-sdk.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 4fbda0e3-5676-4a8f-ba62-3fba59fa418b
 title: What's new in the Open XML SDK 2.5 for Office
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/word-processing.md
+++ b/docs/word-processing.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 4fcb7fbb-0796-4737-8f05-acbcfa9e1a06
 title: Word processing (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/working-with-animation.md
+++ b/docs/working-with-animation.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: d4ef73a6-888a-4476-9e21-4df76782127f
 title: Working with animation (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/working-with-comments.md
+++ b/docs/working-with-comments.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: d7f0f1d3-bcf9-40b5-aaa4-4a08d862ac8e
 title: Working with comments (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/working-with-conditional-formatting.md
+++ b/docs/working-with-conditional-formatting.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: b6f5afca-5feb-4003-b803-55dd2f9bf6d2
 title: Working with conditional formatting (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/working-with-formulas.md
+++ b/docs/working-with-formulas.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 17abd341-abe9-4eee-9bb3-27fded0b04d2
 title: Working with formulas (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/working-with-handout-master-slides.md
+++ b/docs/working-with-handout-master-slides.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: fb4b293c-9a23-44b7-8af6-afe5fac6611a
 title: Working with handout master slides (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/working-with-notes-slides.md
+++ b/docs/working-with-notes-slides.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 56d28bc5-c9ea-4c0e-b2f5-20be9c16d290
 title: Working with notes slides (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/working-with-paragraphs.md
+++ b/docs/working-with-paragraphs.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 8a9117f7-066e-409c-8681-a26610c0eede
 title: Working with paragraphs (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/working-with-pivottables.md
+++ b/docs/working-with-pivottables.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 96697c37-3fa7-4814-85b6-657439435ce1
 title: Working with PivotTables (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/working-with-presentation-slides.md
+++ b/docs/working-with-presentation-slides.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: ee6c905b-26c5-4aed-a414-9aa826364a23
 title: Working with presentation slides (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/working-with-presentationml-documents.md
+++ b/docs/working-with-presentationml-documents.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 56aeeed4-24ce-42ba-a236-6fec6785dd93
 title: Working with PresentationML documents (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/working-with-presentations.md
+++ b/docs/working-with-presentations.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 82deb499-7479-474d-9d89-c4847e6f3649
 title: Working with presentations (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/working-with-runs.md
+++ b/docs/working-with-runs.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 1fbc6d30-bfe4-4b2b-8fd8-0c5a400d1e03
 title: Working with runs (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/working-with-sheets.md
+++ b/docs/working-with-sheets.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 119a7eb6-9a02-4914-b651-9ba090bf7994
 title: Working with sheets (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/working-with-slide-layouts.md
+++ b/docs/working-with-slide-layouts.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 1ec087c3-8b9e-46a9-9c3c-14586908eb0e
 title: Working with slide layouts (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/working-with-slide-masters.md
+++ b/docs/working-with-slide-masters.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 7dfd78a3-e233-4abd-8c17-1e384780d3ec
 title: Working with slide masters (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/working-with-spreadsheetml-documents.md
+++ b/docs/working-with-spreadsheetml-documents.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: c984c74e-2f06-4aba-a64b-2bb928b2929e
 title: Working with SpreadsheetML documents (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/working-with-tables.md
+++ b/docs/working-with-tables.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 7b72277f-3c5e-43ba-bbd8-7467cf532c95
 title: Working with SpreadsheetML tables (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/working-with-the-calculation-chain.md
+++ b/docs/working-with-the-calculation-chain.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: ffdf5bd3-53f5-4f48-8946-11a0287fb107
 title: Working with the calculation chain (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/working-with-the-shared-string-table.md
+++ b/docs/working-with-the-shared-string-table.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: OPENXML
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 36664cc7-30ef-4e9b-b569-846a9e404219
 title: Working with the shared string table (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/working-with-wordprocessingml-documents.md
+++ b/docs/working-with-wordprocessingml-documents.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: bead244f-b551-477f-a296-41ead7bfcf5c
 title: Working with WordprocessingML documents (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual

--- a/docs/working-with-wordprocessingml-tables.md
+++ b/docs/working-with-wordprocessingml-tables.md
@@ -1,5 +1,5 @@
 ---
-ms.prod: MULTIPLEPRODUCTS
+
 api_name:
 - Microsoft.Office.DocumentFormat.OpenXML.Packaging
 api_type:
@@ -7,7 +7,7 @@ api_type:
 ms.assetid: 7b72277f-3c5e-43ba-bbd8-7467cf532c95
 title: Working with WordprocessingML tables (Open XML SDK)
 ms.suite: office
-ms.technology: open-xml
+
 ms.author: o365devx
 author: o365devx
 ms.topic: conceptual


### PR DESCRIPTION
@AlfredHellstern @tomjebo This PR removes metadata from the topic level. At build time, the global metadata supplied in the docfx.json will be applied. 