### PR TITLE
Update how-to-insert-a-picture-into-a-word-processing-document.md

### DIFF
--- a/docs/how-to-insert-a-picture-into-a-word-processing-document.md
+++ b/docs/how-to-insert-a-picture-into-a-word-processing-document.md
@@ -236,7 +236,7 @@ Then, append the reference to the body. The element should be in a [Run](https:/
                                                 ) With {.Preset = A.ShapeTypeValues.Rectangle} _
                                             ) _
                                         ) _
-                                    ) With {.Uri = "https://schemas.openxmlformats.org/drawingml/2006/picture"} _
+                                    ) With {.Uri = "http://schemas.openxmlformats.org/drawingml/2006/picture"} _
                                 ) _
                             ) With {.DistanceFromTop = 0UI, _
                                     .DistanceFromBottom = 0UI, _


### PR DESCRIPTION
Fixed remaining invalid `https://;` as per https://github.com/dotnet/Open-XML-SDK/issues/796#issuecomment-800594426